### PR TITLE
Add support for language id and initialized message

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/RawCommandServerDefinition.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/RawCommandServerDefinition.java
@@ -33,18 +33,30 @@ public class RawCommandServerDefinition extends CommandServerDefinition {
     }
 
     /**
-     * Creates new instance.
+     * Creates new instance with the given languag id which is different from the file extension.
      *
      * @param ext     The extension
+     * @param id      The language server id
      * @param command The command to run
      */
-    public RawCommandServerDefinition(String ext, String[] command) {
+    public RawCommandServerDefinition(String ext, String id, String[] command) {
         this.ext = ext;
-        this.id = ext;
+        this.id = id;
         this.command = command;
         this.typ = "rawCommand";
         this.presentableTyp = "Raw command";
     }
+
+    /**
+     * Creates new instance.
+     *
+     * @param ext The extension
+     * @param command The command to run
+     */
+    public RawCommandServerDefinition(String ext, String[] command) {
+        this(ext, ext, command);
+    }
+
 
     /**
      * Transforms an array of string into the corresponding UserConfigurableServerDefinition

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -37,6 +37,7 @@ import org.eclipse.lsp4j.FormattingCapabilities;
 import org.eclipse.lsp4j.HoverCapabilities;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.InitializedParams;
 import org.eclipse.lsp4j.OnTypeFormattingCapabilities;
 import org.eclipse.lsp4j.RangeFormattingCapabilities;
 import org.eclipse.lsp4j.ReferencesCapabilities;
@@ -458,6 +459,8 @@ public class LanguageServerWrapper {
                         requestManager = new DefaultRequestManager(this, languageServer, client, res.getCapabilities());
                     }
                     setStatus(STARTED);
+                    // send the initialized message since some langauge servers depends on this message
+                    requestManager.initialized(new InitializedParams());
                     return res;
                 });
                 initializeStartTime = System.currentTimeMillis();


### PR DESCRIPTION
## Purpose
Now the RawCommandServerDefinition support for providing a language id
in addition to extension for language servers which has different id
than the extension.

Also the Initialized message is not send to language server once the
client finishes the initialization since some language servers depends
on it.

## Goals
Add support for STS4 Language server
