### PR TITLE
Add support for resetting a failed or timed out language server

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/LSPServerStatusWidget.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/LSPServerStatusWidget.java
@@ -124,6 +124,10 @@ public class LSPServerStatusWidget implements StatusBarWidget {
                         actions.add(new ShowConnectedFiles());
                     }
                     actions.add(new ShowTimeouts());
+                    if (wrapper.isResettable()) {
+                        actions.add(new Reset());
+                    }
+
                     String title = "Server actions";
                     DataContext context = DataManager.getInstance().getDataContext(component);
                     DefaultActionGroup group = new DefaultActionGroup(actions);
@@ -179,6 +183,19 @@ public class LSPServerStatusWidget implements StatusBarWidget {
                     message.append("</html>");
                     Messages.showInfoMessage(message.toString(), "Timeouts");
                 }
+            }
+
+            class Reset extends AnAction implements DumbAware {
+
+                Reset() {
+                    super("&Reset", "Reset the server so it can be started again.", null);
+                }
+
+                @Override
+                public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
+                    wrapper.reset();
+                }
+
             }
 
             @Override

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -601,5 +601,23 @@ public class LanguageServerWrapper {
             connect(editors.get(0));
         }
     }
+
+    /**
+     * Is the langauge server in a state where it can be resettable. Normally language server is
+     * resettable if it has timedout or has a startup error.
+     */
+    public boolean isResettable() {
+        return status == STOPPED && (alreadyShownTimeout || alreadyShownCrash);
+    }
+
+    /**
+     * Reset language server wrapper state so it can be started again if it was failed earlier.
+     */
+    public void reset() {
+        if (isResettable()) {
+            alreadyShownCrash = false;
+            alreadyShownTimeout = false;
+        }
+    }
 }
 


### PR DESCRIPTION
## Purpose
Add support to reset the language server wrapper. because today if the language server timeouts you need to restart the IDE to get it started again. Some time when the system is busy the language server might timeout. Therefore i have added a new menu item to the language server widget to reset the LSP wrapper so than without restarting the IDE, you can reopen your editor which will start the language server back.

## Goals
By resetting the language server the user can restart it by opening the file editor again.

