### PR TITLE
Add support for file name patterns for server registration

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -141,7 +141,7 @@ public class IntellijLanguageClient implements ApplicationComponent {
             ApplicationUtils.pool(() -> {
                 String ext = file.getExtension();
                 final String fileName = file.getName();
-                LOG.info("Opened " + file.getName());
+                LOG.info("Opened " + fileName);
 
                 // The ext can be a file name or it can be a file pattern or the extension.
                 // First try for the extension since it is the most comment usage, if not try to

--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -143,7 +143,7 @@ public class IntellijLanguageClient implements ApplicationComponent {
                 final String fileName = file.getName();
                 LOG.info("Opened " + fileName);
 
-                // The ext can be a file name or it can be a file pattern or the extension.
+                // The ext can either be a file extension or a file pattern(regex expression).
                 // First try for the extension since it is the most comment usage, if not try to
                 // match file name.
                 LanguageServerDefinition serverDefinition = extToServerDefinition.get(ext);


### PR DESCRIPTION
## Purpose
In addition to extension, file name pattern support is added. The first
priority is given for extension and then for the file name pattern when
resolving server definitions.

## Goals
To be able to register the language server based on file name pattern like "application.*\.properties" for Spring Boot property file for example.
