### PR TITLE
Add initial support for listening to server responses

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -32,6 +32,7 @@ import com.intellij.openapi.vfs.VirtualFileManager;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.wso2.lsp4intellij.client.languageserver.serverdefinition.LanguageServerDefinition;
 import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
 import org.wso2.lsp4intellij.editor.listeners.EditorListener;
@@ -341,5 +342,13 @@ public class IntellijLanguageClient implements ApplicationComponent {
 
     public static Map<String, Set<LanguageServerWrapper>> getProjectToLanguageWrappers() {
         return projectToLanguageWrappers;
+    }
+
+    public static void didChangeConfiguration(DidChangeConfigurationParams params,
+        Project project) {
+        final Set<LanguageServerWrapper> serverWrappers = IntellijLanguageClient
+            .getProjectToLanguageWrappers()
+            .get(FileUtils.pathToUri(project.getBasePath()));
+        serverWrappers.forEach(s -> s.getRequestManager().didChangeConfiguration(params));
     }
 }

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/LanguageServerDefinition.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/LanguageServerDefinition.java
@@ -125,4 +125,8 @@ public class LanguageServerDefinition {
     public StreamConnectionProvider createConnectionProvider(String workingDir) {
         throw new UnsupportedOperationException();
     }
+
+    public ServerListener getServerListener() {
+        return ServerListener.NO_OP;
+    }
 }

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/LanguageServerDefinition.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/LanguageServerDefinition.java
@@ -127,6 +127,6 @@ public class LanguageServerDefinition {
     }
 
     public ServerListener getServerListener() {
-        return ServerListener.NO_OP;
+        return ServerListener.DEFAULT;
     }
 }

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/ServerListener.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/ServerListener.java
@@ -6,7 +6,7 @@ import org.jetbrains.annotations.NotNull;
 
 public interface ServerListener {
 
-  public static final ServerListener NO_OP = new ServerListener() {
+  public static final ServerListener DEFAULT = new ServerListener() {
   };
 
 

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/ServerListener.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/ServerListener.java
@@ -1,0 +1,15 @@
+package org.wso2.lsp4intellij.client.languageserver.serverdefinition;
+
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.jetbrains.annotations.NotNull;
+
+public interface ServerListener {
+
+  public static final ServerListener NO_OP = new ServerListener() {
+  };
+
+
+  public default void initilize(@NotNull LanguageServer server, @NotNull InitializeResult result) {
+  }
+}

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -22,6 +22,24 @@ import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -433,18 +451,26 @@ public class LanguageServerWrapper {
                 OutputStream outputStream = streams.getValue();
                 client = serverDefinition.createLanguageClient();
                 InitializeParams initParams = getInitParams();
+                ExecutorService executorService = Executors.newCachedThreadPool();
+                MessageHandler messageHandler = new MessageHandler(
+                    serverDefinition.getServerListener());
                 if (extManager != null) {
                     Class<? extends LanguageServer> remoteServerInterFace = extManager.getExtendedServerInterface();
                     Launcher<? extends LanguageServer> launcher = Launcher
-                            .createLauncher(client, remoteServerInterFace, inputStream, outputStream);
+                        .createLauncher(client, remoteServerInterFace, inputStream, outputStream,
+                            executorService,
+                            messageHandler);
                     languageServer = launcher.getRemoteProxy();
                     launcherFuture = launcher.startListening();
                 } else {
                     Launcher<LanguageServer> launcher = Launcher
-                            .createLauncher(client, LanguageServer.class, inputStream, outputStream);
+                        .createLauncher(client, LanguageServer.class, inputStream, outputStream,
+                            executorService,
+                            messageHandler);
                     languageServer = launcher.getRemoteProxy();
                     launcherFuture = launcher.startListening();
                 }
+                messageHandler.setLanguageServer(languageServer);
 
                 initializeFuture = languageServer.initialize(initParams).thenApply(res -> {
                     initializeResult = res;

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/MessageHandler.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/MessageHandler.java
@@ -1,0 +1,43 @@
+package org.wso2.lsp4intellij.client.languageserver.wrapper;
+
+import java.util.function.Function;
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
+import org.eclipse.lsp4j.jsonrpc.messages.Message;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseMessage;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.jetbrains.annotations.NotNull;
+import org.wso2.lsp4intellij.client.languageserver.serverdefinition.ServerListener;
+
+class MessageHandler implements Function<MessageConsumer, MessageConsumer> {
+
+    private ServerListener listener;
+    private LanguageServer languageServer;
+
+    public MessageHandler(ServerListener listener) {
+        this.listener = listener;
+    }
+
+
+    @Override
+    public MessageConsumer apply(MessageConsumer messageConsumer) {
+        return message -> {
+            handleMessage(message);
+            messageConsumer.consume(message);
+        };
+
+    }
+
+    private void handleMessage(Message message) {
+        if (message instanceof ResponseMessage) {
+            ResponseMessage responseMessage = (ResponseMessage) message;
+            if (responseMessage.getResult() instanceof InitializeResult) {
+                listener.initilize(languageServer, (InitializeResult) responseMessage.getResult());
+            }
+        }
+    }
+
+    public void setLanguageServer(@NotNull LanguageServer languageServer) {
+        this.languageServer = languageServer;
+    }
+}


### PR DESCRIPTION
When adding support for certain language servers, there is a need to receive server notifications. For example if the client needs to initially send a didChangeConfiguration then we need to wait until the server is initialize according to https://microsoft.github.io/language-server-protocol/specification#initialize. This server listener will help to receive such notifications from the server.

Right now it only support **InitializeResult** message, but the design can be extended support more notifications without breaking the backward compatibility.