### PR TITLE
Fix completion insertion and caret positioning

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -807,9 +807,9 @@ public class EditorEventManager {
         LookupElementBuilder lookupElementBuilder;
 
         if (insertText != null && !insertText.equals("")) {
-            lookupElementBuilder = LookupElementBuilder.create(insertText);
+            lookupElementBuilder = LookupElementBuilder.create(insertText, "");
         } else if (label != null && !label.equals("")) {
-            lookupElementBuilder = LookupElementBuilder.create(label);
+            lookupElementBuilder = LookupElementBuilder.create(label, "");
         } else {
             return LookupElementBuilder.create((String) null);
         }
@@ -837,7 +837,8 @@ public class EditorEventManager {
         }
 
         return lookupElementBuilder.withPresentableText(presentableText).withTypeText(tailText, true).withIcon(icon)
-                .withAutoCompletionPolicy(AutoCompletionPolicy.SETTINGS_DEPENDENT);
+            .withLookupString(presentableText)
+            .withAutoCompletionPolicy(AutoCompletionPolicy.SETTINGS_DEPENDENT);
     }
 
     /**
@@ -964,7 +965,7 @@ public class EditorEventManager {
                     } else {
                         text = text.replace(DocumentUtils.WIN_SEPARATOR, DocumentUtils.LINUX_SEPARATOR);
                         if (end >= 0) {
-                            if (end - start <= 0) {
+                            if (end - start <= 0 || end - start != text.length()) {
                                 document.insertString(start, text);
                             } else {
                                 document.replaceString(start, end, text);
@@ -974,6 +975,7 @@ public class EditorEventManager {
                         } else if (start > 0) {
                             document.insertString(start, text);
                         }
+                        editor.getCaretModel().moveToOffset(start + text.length());
                     }
                     saveDocument();
                 });

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -15,6 +15,28 @@
  */
 package org.wso2.lsp4intellij.editor;
 
+import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.HOVER_TIME_THRES;
+import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.POPUP_THRES;
+import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.SCHEDULE_THRES;
+import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getCtrlRange;
+import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getIsCtrlDown;
+import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getIsKeyPressed;
+import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.setCtrlRange;
+import static org.wso2.lsp4intellij.requests.Timeout.getTimeout;
+import static org.wso2.lsp4intellij.requests.Timeouts.CODEACTION;
+import static org.wso2.lsp4intellij.requests.Timeouts.COMPLETION;
+import static org.wso2.lsp4intellij.requests.Timeouts.DEFINITION;
+import static org.wso2.lsp4intellij.requests.Timeouts.EXECUTE_COMMAND;
+import static org.wso2.lsp4intellij.requests.Timeouts.HOVER;
+import static org.wso2.lsp4intellij.requests.Timeouts.REFERENCES;
+import static org.wso2.lsp4intellij.requests.Timeouts.WILLSAVE;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableReadAction;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableWriteAction;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeLater;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.pool;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.writeAction;
+
+import com.google.common.base.Strings;
 import com.intellij.codeHighlighting.Pass;
 import com.intellij.codeHighlighting.TextEditorHighlightingPass;
 import com.intellij.codeInsight.completion.InsertionContext;
@@ -63,6 +85,22 @@ import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.ui.Hint;
+import java.awt.Cursor;
+import java.awt.Point;
+import java.io.File;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+import java.util.Timer;
+import java.util.TimerTask;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.swing.Icon;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.CodeActionParams;
@@ -115,43 +153,6 @@ import org.wso2.lsp4intellij.requests.WorkspaceEditHandler;
 import org.wso2.lsp4intellij.utils.DocumentUtils;
 import org.wso2.lsp4intellij.utils.FileUtils;
 import org.wso2.lsp4intellij.utils.GUIUtils;
-
-import java.awt.*;
-import java.io.File;
-import java.net.URI;
-import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
-import java.util.Timer;
-import java.util.TimerTask;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import javax.swing.*;
-
-import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.HOVER_TIME_THRES;
-import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.POPUP_THRES;
-import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.SCHEDULE_THRES;
-import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getCtrlRange;
-import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getIsCtrlDown;
-import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getIsKeyPressed;
-import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.setCtrlRange;
-import static org.wso2.lsp4intellij.requests.Timeout.getTimeout;
-import static org.wso2.lsp4intellij.requests.Timeouts.CODEACTION;
-import static org.wso2.lsp4intellij.requests.Timeouts.COMPLETION;
-import static org.wso2.lsp4intellij.requests.Timeouts.DEFINITION;
-import static org.wso2.lsp4intellij.requests.Timeouts.EXECUTE_COMMAND;
-import static org.wso2.lsp4intellij.requests.Timeouts.HOVER;
-import static org.wso2.lsp4intellij.requests.Timeouts.REFERENCES;
-import static org.wso2.lsp4intellij.requests.Timeouts.WILLSAVE;
-import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableReadAction;
-import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableWriteAction;
-import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeLater;
-import static org.wso2.lsp4intellij.utils.ApplicationUtils.pool;
-import static org.wso2.lsp4intellij.utils.ApplicationUtils.writeAction;
 
 /**
  * Class handling events related to an Editor (a Document)
@@ -806,10 +807,12 @@ public class EditorEventManager {
         Icon icon = iconProvider.getCompletionIcon(kind);
         LookupElementBuilder lookupElementBuilder;
 
-        if (insertText != null && !insertText.equals("")) {
-            lookupElementBuilder = LookupElementBuilder.create(insertText, "");
-        } else if (label != null && !label.equals("")) {
+        if (!Strings.isNullOrEmpty(label)) {
             lookupElementBuilder = LookupElementBuilder.create(label, "");
+        } else if (textEdit != null) {
+            lookupElementBuilder = LookupElementBuilder.create(textEdit.getNewText(), "");
+        } else if (!Strings.isNullOrEmpty(insertText)) {
+            lookupElementBuilder = LookupElementBuilder.create(insertText, "");
         } else {
             return LookupElementBuilder.create((String) null);
         }
@@ -965,7 +968,7 @@ public class EditorEventManager {
                     } else {
                         text = text.replace(DocumentUtils.WIN_SEPARATOR, DocumentUtils.LINUX_SEPARATOR);
                         if (end >= 0) {
-                            if (end - start <= 0 || end - start != text.length()) {
+                            if (end - start <= 0) {
                                 document.insertString(start, text);
                             } else {
                                 document.replaceString(start, end, text);

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -85,6 +85,7 @@ import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.ui.Hint;
+
 import java.awt.Cursor;
 import java.awt.Point;
 import java.io.File;
@@ -101,6 +102,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.swing.Icon;
+
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.CodeActionParams;
@@ -200,8 +202,8 @@ public class EditorEventManager {
 
     //Todo - Revisit arguments order and add remaining listeners
     public EditorEventManager(Editor editor, DocumentListener documentListener, EditorMouseListener mouseListener,
-            EditorMouseMotionListener mouseMotionListener, RequestManager requestManager, ServerOptions serverOptions,
-            LanguageServerWrapper wrapper) {
+                              EditorMouseMotionListener mouseMotionListener, RequestManager requestManager, ServerOptions serverOptions,
+                              LanguageServerWrapper wrapper) {
 
         this.editor = editor;
         this.documentListener = documentListener;
@@ -778,8 +780,9 @@ public class EditorEventManager {
         } catch (JsonRpcException | ExecutionException | InterruptedException e) {
             LOG.warn(e);
             wrapper.crashed(e);
+        } finally {
+            return lookupItems;
         }
-        return lookupItems;
     }
 
     /**
@@ -807,12 +810,12 @@ public class EditorEventManager {
         Icon icon = iconProvider.getCompletionIcon(kind);
         LookupElementBuilder lookupElementBuilder;
 
-        if (!Strings.isNullOrEmpty(label)) {
-            lookupElementBuilder = LookupElementBuilder.create(label, "");
-        } else if (textEdit != null) {
-            lookupElementBuilder = LookupElementBuilder.create(textEdit.getNewText(), "");
+        if (textEdit != null) {
+            lookupElementBuilder = LookupElementBuilder.create("");
         } else if (!Strings.isNullOrEmpty(insertText)) {
-            lookupElementBuilder = LookupElementBuilder.create(insertText, "");
+            lookupElementBuilder = LookupElementBuilder.create(insertText);
+        } else if (!Strings.isNullOrEmpty(label)) {
+            lookupElementBuilder = LookupElementBuilder.create(label);
         } else {
             return LookupElementBuilder.create((String) null);
         }
@@ -840,8 +843,7 @@ public class EditorEventManager {
         }
 
         return lookupElementBuilder.withPresentableText(presentableText).withTypeText(tailText, true).withIcon(icon)
-            .withLookupString(presentableText)
-            .withAutoCompletionPolicy(AutoCompletionPolicy.SETTINGS_DEPENDENT);
+                .withAutoCompletionPolicy(AutoCompletionPolicy.SETTINGS_DEPENDENT);
     }
 
     /**
@@ -898,7 +900,7 @@ public class EditorEventManager {
     }
 
     private LookupElementBuilder setInsertHandler(LookupElementBuilder builder, List<TextEdit> edits, Command command,
-            String label) {
+                                                  String label) {
         return builder.withInsertHandler((InsertionContext context, LookupElement lookupElement) -> {
             context.commitDocument();
             invokeLater(() -> {

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -833,9 +833,6 @@ public class EditorEventManager {
         if (textEdit != null) {
             if (addTextEdits != null) {
                 lookupElementBuilder = setInsertHandler(lookupElementBuilder, addTextEdits, command, label);
-            } else {
-                lookupElementBuilder = setInsertHandler(lookupElementBuilder, Collections.emptyList(),
-                        command, label);
             }
         } else if (addTextEdits != null) {
             lookupElementBuilder = setInsertHandler(lookupElementBuilder, addTextEdits, command, label);


### PR DESCRIPTION
When creating lookup item we need to provide the lookup object and then
set the lookup string.
When processing text edit the replace must be perform if the range length
is not equal to newText length.
