### PR TITLE
Fix NPE when trying to open virual files which doesn't exist

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -29,6 +29,18 @@ import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
+import java.util.AbstractMap;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
@@ -43,19 +55,6 @@ import org.wso2.lsp4intellij.requests.Timeout;
 import org.wso2.lsp4intellij.requests.Timeouts;
 import org.wso2.lsp4intellij.utils.ApplicationUtils;
 import org.wso2.lsp4intellij.utils.FileUtils;
-
-import java.util.AbstractMap;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Optional;
-import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import java.util.stream.Stream;
 
 public class IntellijLanguageClient implements ApplicationComponent {
 
@@ -141,6 +140,11 @@ public class IntellijLanguageClient implements ApplicationComponent {
      */
     public static void editorOpened(Editor editor) {
         VirtualFile file = FileDocumentManager.getInstance().getFile(editor.getDocument());
+        if (!FileUtils.isFileSupported(file)) {
+            LOG.debug("Handling open on a editor which host a virtual file");
+            return;
+        }
+
         Project project = editor.getProject();
         String rootPath = FileUtils.editorToProjectFolderPath(editor);
         String rootUri = FileUtils.pathToUri(rootPath);
@@ -208,6 +212,11 @@ public class IntellijLanguageClient implements ApplicationComponent {
      */
     public static void editorClosed(Editor editor) {
         VirtualFile file = FileDocumentManager.getInstance().getFile(editor.getDocument());
+        if (!FileUtils.isFileSupported(file)) {
+            LOG.debug("Handling close on a editor which host a virtual file");
+            return;
+        }
+
         if (file != null) {
             ApplicationUtils.pool(() -> {
                 String ext = file.getExtension();

--- a/src/main/java/org/wso2/lsp4intellij/utils/FileUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/FileUtils.java
@@ -27,6 +27,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import com.intellij.testFramework.LightVirtualFileBase;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.jetbrains.annotations.Nullable;
 
@@ -224,4 +225,10 @@ public class FileUtils {
         WINDOWS, UNIX
     }
 
+    /**
+     * Checks if the file instance is supported by this LS client library.
+     */
+    public static boolean isFileSupported(VirtualFile file) {
+        return !(file instanceof LightVirtualFileBase);
+    }
 }


### PR DESCRIPTION
Idea use virtual files for code snippets which are marked as
LightVirtualFile. These files are not part of the LS workspace.
These kind of file editors are used in TestNG Run Configuration for
example.

Fix for https://github.com/ballerina-platform/lsp4intellij/issues/66