### PR TITLE
Change access modifiers

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/DefaultRequestManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/DefaultRequestManager.java
@@ -87,13 +87,14 @@ import java.util.concurrent.CompletableFuture;
 public class DefaultRequestManager implements RequestManager {
 
     private Logger LOG = Logger.getInstance(DefaultRequestManager.class);
+
+    public LanguageServerWrapper wrapper;
+    public LanguageServer server;
+    public LanguageClient client;
+    public ServerCapabilities serverCapabilities;
     private TextDocumentSyncOptions textDocumentOptions;
     private WorkspaceService workspaceService;
     private TextDocumentService textDocumentService;
-    private LanguageServerWrapper wrapper;
-    private LanguageServer server;
-    private LanguageClient client;
-    private ServerCapabilities serverCapabilities;
 
     public DefaultRequestManager(LanguageServerWrapper wrapper, LanguageServer server, LanguageClient client,
             ServerCapabilities serverCapabilities) {
@@ -635,7 +636,7 @@ public class DefaultRequestManager implements RequestManager {
         return null;
     }
 
-    private boolean checkStatus() {
+    public boolean checkStatus() {
         return wrapper.getStatus() == ServerStatus.INITIALIZED;
     }
 

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/DefaultRequestManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/DefaultRequestManager.java
@@ -88,10 +88,10 @@ public class DefaultRequestManager implements RequestManager {
 
     private Logger LOG = Logger.getInstance(DefaultRequestManager.class);
 
-    public LanguageServerWrapper wrapper;
-    public LanguageServer server;
-    public LanguageClient client;
-    public ServerCapabilities serverCapabilities;
+    private LanguageServerWrapper wrapper;
+    private LanguageServer server;
+    private LanguageClient client;
+    private ServerCapabilities serverCapabilities;
     private TextDocumentSyncOptions textDocumentOptions;
     private WorkspaceService workspaceService;
     private TextDocumentService textDocumentService;
@@ -109,6 +109,22 @@ public class DefaultRequestManager implements RequestManager {
                 null;
         workspaceService = server.getWorkspaceService();
         textDocumentService = server.getTextDocumentService();
+    }
+
+    public LanguageServerWrapper getWrapper() {
+        return wrapper;
+    }
+
+    public LanguageClient getClient() {
+        return client;
+    }
+
+    public LanguageServer getServer() {
+        return server;
+    }
+
+    public ServerCapabilities getServerCapabilities() {
+        return serverCapabilities;
     }
 
     //Client

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -172,9 +172,9 @@ public class EditorEventManager {
     public Editor editor;
     public LanguageServerWrapper wrapper;
     public List<String> completionTriggers;
-    public Project project;
-    public RequestManager requestManager;
-    public TextDocumentIdentifier identifier;
+    private Project project;
+    private RequestManager requestManager;
+    private TextDocumentIdentifier identifier;
     private ServerOptions serverOptions;
     private DocumentListener documentListener;
     private EditorMouseListener mouseListener;
@@ -232,6 +232,18 @@ public class EditorEventManager {
         this.inspectionToolWrapper = Collections.singletonList(new LocalInspectionToolWrapper(new LSPInspection()));
         this.inspectionsPassFactory = project.getComponent(LocalInspectionsPassFactory.class);
         this.currentHint = null;
+    }
+
+    public Project getProject() {
+        return project;
+    }
+
+    public RequestManager getRequestManager() {
+        return requestManager;
+    }
+
+    public TextDocumentIdentifier getIdentifier() {
+        return identifier;
     }
 
     /**

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -172,10 +172,10 @@ public class EditorEventManager {
     public Editor editor;
     public LanguageServerWrapper wrapper;
     public List<String> completionTriggers;
-    protected Project project;
-    private RequestManager requestManager;
+    public Project project;
+    public RequestManager requestManager;
+    public TextDocumentIdentifier identifier;
     private ServerOptions serverOptions;
-    private TextDocumentIdentifier identifier;
     private DocumentListener documentListener;
     private EditorMouseListener mouseListener;
     private EditorMouseMotionListener mouseMotionListener;


### PR DESCRIPTION
## Purpose
When supporting custom LSP extensions, the developer needs more accessibility for the client components. This PR updates access modifiers of few such components. 