### PR TITLE
Fix "Can't remove document listener" issue

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -357,12 +357,12 @@ public class LanguageServerWrapper {
      * @param uri The uri of the editor
      */
     public void disconnect(String uri) {
-        connectedEditors.remove(uri);
-        connectedEditors.forEach((key, value) -> {
+        EditorEventManager manager = connectedEditors.remove(uri);
+        if (manager != null) {
+            manager.removeListeners();
+            manager.documentClosed();
             uriToLanguageServerWrapper.remove(new ImmutablePair<>(uri, FileUtils.projectToUri(project)));
-            value.removeListeners();
-            value.documentClosed();
-        });
+        }
 
         if (connectedEditors.isEmpty()) {
             stop(true);

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -116,6 +116,7 @@ import org.wso2.lsp4intellij.utils.DocumentUtils;
 import org.wso2.lsp4intellij.utils.FileUtils;
 import org.wso2.lsp4intellij.utils.GUIUtils;
 
+import javax.swing.*;
 import java.awt.*;
 import java.io.File;
 import java.net.URI;
@@ -130,7 +131,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import javax.swing.*;
 
 import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.HOVER_TIME_THRES;
 import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.POPUP_THRES;

--- a/src/main/java/org/wso2/lsp4intellij/utils/ApplicationUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/ApplicationUtils.java
@@ -17,15 +17,32 @@ package org.wso2.lsp4intellij.utils;
 
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.util.Computable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class ApplicationUtils {
+
+    private static final ExecutorService EXECUTOR_SERVICE;
+
+    static {
+        // Single threaded executor is used to simulate a behavior of async sequencial execution.
+        // All runnables are executed asyncly but they are executed in the order of their submission.
+        EXECUTOR_SERVICE = Executors.newSingleThreadExecutor();
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                EXECUTOR_SERVICE.shutdownNow();
+            }
+        });
+    }
+
 
     static public void invokeLater(Runnable runnable) {
         ApplicationManager.getApplication().invokeLater(runnable);
     }
 
     static public void pool(Runnable runnable) {
-        ApplicationManager.getApplication().executeOnPooledThread(runnable);
+        EXECUTOR_SERVICE.submit(runnable);
     }
 
     static public <T> T computableReadAction(Computable<T> computable) {


### PR DESCRIPTION
Fix "Can't remove document listener" by removing some unwanted document
listener removals on connected editor. This also fixed the issue of LS
error when opening lot of files while the LS is starting.

