### PR TITLE
Fix NPE at LSPInspection when the virtual file is null.

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/contributors/inspection/LSPInspection.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/inspection/LSPInspection.java
@@ -57,7 +57,8 @@ public class LSPInspection extends LocalInspectionTool implements DumbAware {
             boolean isOnTheFly) {
 
         VirtualFile virtualFile = file.getVirtualFile();
-        if (IntellijLanguageClient.isExtensionSupported(virtualFile.getExtension())) {
+        if (FileUtils.isFileSupported(virtualFile) &&
+                IntellijLanguageClient.isExtensionSupported(virtualFile.getExtension())) {
             String uri = FileUtils.VFSToURI(virtualFile);
             EditorEventManager eventManager = EditorEventManagerBase.forUri(uri);
             if (eventManager != null) {

--- a/src/main/java/org/wso2/lsp4intellij/utils/FileUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/FileUtils.java
@@ -228,7 +228,7 @@ public class FileUtils {
     /**
      * Checks if the file instance is supported by this LS client library.
      */
-    public static boolean isFileSupported(VirtualFile file) {
+    public static boolean isFileSupported(@Nullable VirtualFile file) {
         if (file == null) {
             return false;
         }


### PR DESCRIPTION
Add a file support check in addition the extension check to avoid passing down null virtual files.