### PR TITLE
Add support for async and cancellable completion proposal contributor

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -788,10 +788,10 @@ public class EditorEventManager {
                     }
                 }
             }
-        } catch (TimeoutException e) {
+        } catch (TimeoutException | InterruptedException e) {
             LOG.warn(e);
             wrapper.notifyFailure(Timeouts.COMPLETION);
-        } catch (JsonRpcException | ExecutionException | InterruptedException e) {
+        } catch (JsonRpcException | ExecutionException e) {
             LOG.warn(e);
             wrapper.crashed(e);
         } finally {


### PR DESCRIPTION
When a LS takes lot of time for completion request the IDE freezes due to the fact the IDE cannot cancel that request according to the previous implementation. This cause the completion while typing to cause UI freeze while typing letters. With the fix the request is cancelled if the current progress is cancelled by the IDE. Also added support for providing a PsiElementPattern by the consumer so that the Contributions can be targeted to specific locations in the while by sub classing this contributor to suit consumer language.