### PR TITLE
Enhance support for language id passing when document open

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/ArtifactLanguageServerDefinition.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/ArtifactLanguageServerDefinition.java
@@ -54,7 +54,7 @@ public class ArtifactLanguageServerDefinition extends UserConfigurableServerDefi
      */
     public ArtifactLanguageServerDefinition(String ext, String packge, String mainClass, String[] args) {
         this.ext = ext;
-        this.id = ext;
+        this.languageIds = Collections.emptyMap();
         this.packge = packge;
         this.mainClass = mainClass;
         this.args = args;

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/ExeLanguageServerDefinition.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/ExeLanguageServerDefinition.java
@@ -16,6 +16,7 @@
 package org.wso2.lsp4intellij.client.languageserver.serverdefinition;
 
 import java.util.Arrays;
+import java.util.Collections;
 
 /**
  * Class representing server definitions corresponding to an executable file This class is basically a more convenient
@@ -43,7 +44,7 @@ public class ExeLanguageServerDefinition extends CommandServerDefinition {
      */
     public ExeLanguageServerDefinition(String ext, String path, String[] args) {
         this.ext = ext;
-        this.id = ext;
+        this.languageIds = Collections.emptyMap();
         this.path = path;
         this.args = args;
         this.command = getCommand();

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/LanguageServerDefinition.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/LanguageServerDefinition.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -38,10 +39,8 @@ public class LanguageServerDefinition {
      * The extension that the language server manages.
      */
     public String ext;
-    /**
-     * The id of the language server (same as extension).
-     */
-    public String id;
+
+    protected Map<String, String> languageIds = Collections.emptyMap();
 
     private Map<String, StreamConnectionProvider> streamConnectionProviders = new ConcurrentHashMap<>();
 
@@ -120,5 +119,13 @@ public class LanguageServerDefinition {
 
     public ServerListener getServerListener() {
         return ServerListener.DEFAULT;
+    }
+
+    /**
+     * Return language id for the given extension. if there is no langauge ids registered then the
+     * return value will be the value of <code>extension</code>.
+     */
+    public String languageIdFor(String extension) {
+        return languageIds.getOrDefault(extension, extension);
     }
 }

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/RawCommandServerDefinition.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/RawCommandServerDefinition.java
@@ -18,6 +18,8 @@ package org.wso2.lsp4intellij.client.languageserver.serverdefinition;
 import org.wso2.lsp4intellij.utils.Utils;
 
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 
 /**
  * A class representing a raw command to launch a languageserver
@@ -35,13 +37,13 @@ public class RawCommandServerDefinition extends CommandServerDefinition {
     /**
      * Creates new instance with the given languag id which is different from the file extension.
      *
-     * @param ext     The extension
-     * @param id      The language server id
-     * @param command The command to run
+     * @param ext         The extension
+     * @param languageIds The language server ids mapping to extension(s).
+     * @param command     The command to run
      */
-    public RawCommandServerDefinition(String ext, String id, String[] command) {
+    public RawCommandServerDefinition(String ext, Map<String, String> languageIds, String[] command) {
         this.ext = ext;
-        this.id = id;
+        this.languageIds = languageIds;
         this.command = command;
         this.typ = "rawCommand";
         this.presentableTyp = "Raw command";
@@ -54,7 +56,7 @@ public class RawCommandServerDefinition extends CommandServerDefinition {
      * @param command The command to run
      */
     public RawCommandServerDefinition(String ext, String[] command) {
-        this(ext, ext, command);
+        this(ext, Collections.emptyMap(), command);
     }
 
 

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -1087,8 +1087,12 @@ public class EditorEventManager {
                 if (isOpen) {
                     LOG.warn("Editor " + editor + " was already open");
                 } else {
+                    final String extension = FileDocumentManager.getInstance()
+                            .getFile(editor.getDocument()).getExtension();
                     requestManager.didOpen(new DidOpenTextDocumentParams(
-                            new TextDocumentItem(identifier.getUri(), wrapper.serverDefinition.id, version++,
+                            new TextDocumentItem(identifier.getUri(),
+                                    wrapper.serverDefinition.languageIdFor(extension),
+                                    version++,
                                     editor.getDocument().getText())));
                     isOpen = true;
                 }


### PR DESCRIPTION
With the previous implementation when supporting for multiple language id
which are not same as the ext we need to define multiple language server
definitions which cause multiple language servers to start.

With new implementation we can support for multiple languages with one
server. This also enable proper language id passing when using
extension patterns.

@NipunaRanasinghe i think this PR is really important for us since this is a breaking change if we plan this after 1.0.0

Example usage:
```
Map<String, String> langMapping = new HashMap<String,String>
langMapping.put("java", LANG_ID_JAVA)
langMapping.put("yaml", LANG_ID_YAML)
langMapping.put("yml", LANG_ID_YAML)
langMapping.put("xml", LANG_ID_XML)
langMapping.put("properties", LANG_ID_PROPERTIES)

RawCommandServerDefinition def = new RawCommandServerDefinition("java,application.*\.yaml,application.*\.yml,.*[Cc]ontext.*\.xml,application.*\.properties", langMapping, commands);

```
