### PR TITLE
Add project-level server definition support

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/contributors/symbol/WorkspaceSymbolProvider.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/symbol/WorkspaceSymbolProvider.java
@@ -52,7 +52,7 @@ public class WorkspaceSymbolProvider {
   public List<NavigationItem> workspaceSymbols(String name, Project project) {
     final Set<LanguageServerWrapper> serverWrappers = IntellijLanguageClient
         .getProjectToLanguageWrappers()
-        .getOrDefault(FileUtils.pathToUri(project.getBasePath()), Collections.emptySet());
+        .getOrDefault(FileUtils.projectToUri(project), Collections.emptySet());
 
     final WorkspaceSymbolParams symbolParams = new WorkspaceSymbolParams(name);
     return serverWrappers.stream().filter(s -> s.getStatus() == ServerStatus.INITIALIZED)

--- a/src/main/java/org/wso2/lsp4intellij/utils/FileUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/FileUtils.java
@@ -27,6 +27,7 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.vfs.LocalFileSystem;
 import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.search.FilenameIndex;
 import com.intellij.psi.search.GlobalSearchScope;
@@ -268,7 +269,7 @@ public class FileUtils {
         return Arrays.stream(ProjectManager.getInstance().getOpenProjects())
                 .flatMap(p -> Arrays.stream(searchFiles(file, p)))
                 .filter(f -> f.getVirtualFile().getPath().equals(file.getPath()))
-                .map(f -> f.getProject())
+                .map(PsiElement::getProject)
                 .collect(Collectors.toSet());
     }
 


### PR DESCRIPTION
## Purpose
Currently, when we provide add LS definition using `addServerDefiniton()`, those definition will be added in application-level and will be consumed by the all the opened projects.

This PR introduces support for adding project-specific server definitions, where you can pass the project instance as a parameter.

This will add the support of using different versions of a particular language server for different projects.