### PR TITLE
tiny change to Reformat , so that it will be the same user experience as Java in Intellij IDEA

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/actions/LSPReformatAction.java
+++ b/src/main/java/org/wso2/lsp4intellij/actions/LSPReformatAction.java
@@ -45,7 +45,12 @@ public class LSPReformatAction extends ReformatCodeAction implements DumbAware {
         PsiFile file = PsiDocumentManager.getInstance(project).getPsiFile(editor.getDocument());
         if (LanguageFormatting.INSTANCE.allForLanguage(file.getLanguage()).isEmpty() && IntellijLanguageClient
                 .isExtensionSupported(file.getVirtualFile())) {
-            ReformatHandler.reformatFile(editor);
+            // if editor hasSelection, only reformat selection, not reformat the whole file
+            if (editor.getSelectionModel().hasSelection()) {
+                ReformatHandler.reformatSelection(editor);
+            } else {
+                ReformatHandler.reformatFile(editor);
+            }
         } else {
             super.actionPerformed(e);
         }

--- a/src/main/java/org/wso2/lsp4intellij/actions/LSPShowReformatDialogAction.java
+++ b/src/main/java/org/wso2/lsp4intellij/actions/LSPShowReformatDialogAction.java
@@ -66,7 +66,8 @@ public class LSPShowReformatDialogAction extends ShowReformatFileDialog implemen
                         }
                     }
                 } else {
-                    super.actionPerformed(e);
+                    // if user chose cancel , the dialog in super.actionPerformed(e) will show again
+                    // super.actionPerformed(e);
                 }
             } else {
                 super.actionPerformed(e);


### PR DESCRIPTION
1.  add reformat selection to LSPReformatAction
2.  do not pop out show reformat dialog twice

## Purpose
> 1.  If user has selection in editor when using lsp reformat, our plugin still reformat the whole file for the user. But in Java, it will only reformat selection code.  In order to have the same user experience,  I suggest this pull request
> 2.  If user clicked "cancel" after "Show Reformat File Dialog", our plugin will still pop up the dialog again, as in this [line](https://github.com/ballerina-platform/lsp4intellij/blob/b0e378e60be5a27e7ed1a53ac0076f902fea8ac2/src/main/java/org/wso2/lsp4intellij/actions/LSPShowReformatDialogAction.java#L69)

## Goals
> 1. If user has selection in editor when using lsp reformat, our plugin will only reformat selection
> 2. If user clicked "cancel" after "Show Reformat File Dialog" , the dialog will "cancel" directly. 

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment

openjdk version "11.0.3" 2019-04-16
OpenJDK Runtime Environment (build 11.0.3+12-b304.10)
OpenJDK 64-Bit Server VM (build 11.0.3+12-b304.10, mixed mode)

$ ./clangd --version
clangd version 8.0.0 (tags/RELEASE_800/final)


## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.