### PR TITLE
Replace "ctrl" key functionality to "command" key in mac os

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,17 +198,17 @@ shown below.
 ![](resources/images/lsp4intellij-codeactions.gif)  
 
 #### Go to Definition
-Press the `CTRL` key while clicking on a symbol to navigate to its definition. 
+You can use `CTRL+CLICK`(`COMMAND+CLICK` in MacOS) to navigate to its definition.
  
 ![](resources/images/lsp4intellij-gotodef.gif)
 
 #### Goto References / Find Usages
-You can use `CTRL+CLICK` or `SHIFT+ALT+F7` for a symbol to view the list of its references/usages.
+You can use `CTRL+CLICK`(`COMMAND+CLICK` in MacOS) or `SHIFT+ALT+F7` for a symbol to view the list of its references/usages.
  
 ![](resources/images/lsp4intellij-gotoref.gif)
 
 #### Hover Support
-You can hover over an element while pressing the `CTRL` key to view its documentation if available.
+You can hover over an element while pressing the `CTRL`(`COMMAND` in MacOS) key to view its documentation if available.
 
 ![](resources/images/lsp4intellij-hover.gif)
 
@@ -219,7 +219,7 @@ pops up.
 ![](resources/images/lsp4intellij-workspacesymbols.gif)
 
 #### Renaming Support
-Set the courser to the element which needs to renamed and press `CTRL+F6` to trigger the inplace renaming as shown 
+Set the courser to the element which needs to renamed and press `SHIFT+F6` to trigger the in-place renaming as shown
 below.
 
 ![](resources/images/lsp4intellij-renaming.gif)

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
@@ -17,8 +17,9 @@ package org.wso2.lsp4intellij.editor;
 
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.ex.EditorSettingsExternalizable;
+import org.wso2.lsp4intellij.utils.OSUtils;
 
-import java.awt.*;
+import java.awt.KeyboardFocusManager;
 import java.awt.event.KeyEvent;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
@@ -34,6 +35,7 @@ public class EditorEventManagerBase {
     public static Map<String, EditorEventManager> uriToManager = new ConcurrentHashMap<>();
     public static Map<Editor, EditorEventManager> editorToManager = new ConcurrentHashMap<>();
 
+    private static int CTRL_KEY_CODE = OSUtils.isMac() ? KeyEvent.VK_META : KeyEvent.VK_CONTROL;
     private volatile static boolean isKeyPressed = false;
     private volatile static boolean isCtrlDown = false;
     private volatile static CtrlRangeMarker ctrlRange;
@@ -43,12 +45,12 @@ public class EditorEventManagerBase {
             int eventId = e.getID();
             if (eventId == KeyEvent.KEY_PRESSED) {
                 setIsKeyPressed(true);
-                if (e.getKeyCode() == KeyEvent.VK_CONTROL) {
+                if (e.getKeyCode() == CTRL_KEY_CODE) {
                     setIsCtrlDown(true);
                 }
             } else if (eventId == KeyEvent.KEY_RELEASED) {
                 setIsKeyPressed(false);
-                if (e.getKeyCode() == KeyEvent.VK_CONTROL) {
+                if (e.getKeyCode() == CTRL_KEY_CODE) {
                     setIsCtrlDown(false);
                     if (getCtrlRange() != null) {
                         getCtrlRange().dispose();

--- a/src/main/java/org/wso2/lsp4intellij/utils/OSUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/OSUtils.java
@@ -1,0 +1,40 @@
+package org.wso2.lsp4intellij.utils;
+
+import java.util.Locale;
+
+public class OSUtils {
+
+    public static final String WINDOWS = "windows";
+    public static final String UNIX = "unix";
+    public static final String MAC = "mac";
+
+    private static final String OS = System.getProperty("os.name").toLowerCase(Locale.getDefault());
+
+    /**
+     * Returns name of the operating system running. null if not a unsupported operating system.
+     *
+     * @return operating system
+     */
+    public static String getOperatingSystem() {
+        if (OSUtils.isWindows()) {
+            return WINDOWS;
+        } else if (OSUtils.isUnix()) {
+            return UNIX;
+        } else if (OSUtils.isMac()) {
+            return MAC;
+        }
+        return null;
+    }
+
+    public static boolean isWindows() {
+        return (OS.contains("win"));
+    }
+
+    public static boolean isMac() {
+        return (OS.contains("mac"));
+    }
+
+    public static boolean isUnix() {
+        return (OS.contains("nix") || OS.contains("nux") || OS.contains("aix"));
+    }
+}

--- a/src/main/java/org/wso2/lsp4intellij/utils/OSUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/OSUtils.java
@@ -1,12 +1,27 @@
+/*
+ * Copyright (c) 2018-2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.wso2.lsp4intellij.utils;
 
 import java.util.Locale;
 
 public class OSUtils {
 
-    public static final String WINDOWS = "windows";
-    public static final String UNIX = "unix";
-    public static final String MAC = "mac";
+    private static final String WINDOWS = "windows";
+    private static final String UNIX = "unix";
+    private static final String MAC = "mac";
 
     private static final String OS = System.getProperty("os.name").toLowerCase(Locale.getDefault());
 


### PR DESCRIPTION
## Purpose
$subject since in mac os, goto defs/refs and hover should be triggered when pressing command key (not CTRL).