### PR TITLE
Navigate to line/column in goto definition/references

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -375,17 +375,9 @@ public class EditorEventManager {
                 }
                 if (file != null) {
                     final Position start = loc.getRange().getStart();
-                    OpenFileDescriptor descriptor = new OpenFileDescriptor(project, file, start.getLine(), start.getCharacter());
+                    final OpenFileDescriptor descriptor = new OpenFileDescriptor(project, file, start.getLine(), start.getCharacter());
                     writeAction(() -> {
-                        Editor newEditor = FileEditorManager.getInstance(project).openTextEditor(descriptor, true);
-                        int startOffset = DocumentUtils.LSPPosToOffset(newEditor, loc.getRange().getStart());
-                        if (newEditor != null) {
-                            newEditor.getCaretModel().getCurrentCaret().moveToOffset(startOffset);
-                            newEditor.getSelectionModel().setSelection(startOffset,
-                                    DocumentUtils.LSPPosToOffset(newEditor, loc.getRange().getEnd()));
-                        } else {
-                            LOG.warn("editor is null");
-                        }
+                        FileEditorManager.getInstance(project).openTextEditor(descriptor, true);
                     });
                 } else {
                     LOG.warn("Empty file for " + locUri);

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -374,7 +374,8 @@ public class EditorEventManager {
                     LOG.warn("Syntax Exception occurred for uri: " + locUri);
                 }
                 if (file != null) {
-                    OpenFileDescriptor descriptor = new OpenFileDescriptor(project, file);
+                    final Position start = loc.getRange().getStart();
+                    OpenFileDescriptor descriptor = new OpenFileDescriptor(project, file, start.getLine(), start.getCharacter());
                     writeAction(() -> {
                         Editor newEditor = FileEditorManager.getInstance(project).openTextEditor(descriptor, true);
                         int startOffset = DocumentUtils.LSPPosToOffset(newEditor, loc.getRange().getStart());
@@ -485,7 +486,7 @@ public class EditorEventManager {
                         VirtualFile file = FileUtils.virtualFileFromURI(uri);
                         Editor curEditor = FileUtils.editorFromUri(uri, project);
                         if (curEditor == null) {
-                            OpenFileDescriptor descriptor = new OpenFileDescriptor(project, file);
+                            OpenFileDescriptor descriptor = new OpenFileDescriptor(project, file, start.getLine(), start.getCharacter());
                             curEditor = computableWriteAction(
                                     () -> FileEditorManager.getInstance(project).openTextEditor(descriptor, false));
                             openedEditors.add(file);


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

Per https://github.com/ballerina-platform/lsp4intellij/issues/121, command-clicking on a symbol should "_jump_ to definition", if implemented by LSP.

Instead, currently it only selects the target range in the editor, without navigating to it.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Navigation to the target range on ctrl+click is common in other plugins for IntelliJ, as well as other editors like VS Code. We're just enabling it here.

Additionally, we remove "selection" for the target range, which provides an eyesore if the selection is large (e.g. when the target is a block of code).

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

This PR adds line/column arguments to `OpenFileDescriptor()` constructor, which is used by `openTextEditor()` call to open the target range.

The target line/column is taken to be the first line/char of the target range.

Additionally, it removes previous caret/selection manipulation code that came right after,
but didn't serve the intended purpose (in my view).

![out](https://user-images.githubusercontent.com/137337/63195717-64ea6180-c041-11e9-9d1e-bd01915b6061.gif)


## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

Navigate to line/column in goto definition/references
