### PR TITLE
Add language server restart support

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -267,7 +267,7 @@ public class IntellijLanguageClient implements ApplicationComponent {
         try {
             List<Editor> allOpenedEditors = FileUtils.getAllOpenedEditors(project);
             allOpenedEditors.forEach(IntellijLanguageClient::editorClosed);
-            allOpenedEditors.forEach(IntellijLanguageClient::editorClosed);
+            allOpenedEditors.forEach(IntellijLanguageClient::editorOpened);
         } catch (Exception e) {
             LOG.warn(String.format("Refreshing project: %s is failed due to: ", project.getName()), e);
         }

--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -23,6 +23,7 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.EditorFactory;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.project.Project;
+import com.intellij.openapi.project.ProjectManager;
 import com.intellij.openapi.util.Disposer;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.openapi.vfs.VirtualFileManager;
@@ -38,16 +39,18 @@ import org.wso2.lsp4intellij.editor.listeners.VFSListener;
 import org.wso2.lsp4intellij.extensions.LSPExtensionManager;
 import org.wso2.lsp4intellij.requests.Timeout;
 import org.wso2.lsp4intellij.requests.Timeouts;
-import org.wso2.lsp4intellij.utils.ApplicationUtils;
 import org.wso2.lsp4intellij.utils.FileUtils;
 
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.pool;
 
 public class IntellijLanguageClient implements ApplicationComponent {
 
@@ -91,8 +94,10 @@ public class IntellijLanguageClient implements ApplicationComponent {
         if (definition != null) {
             if (project != null) {
                 processDefinition(definition, FileUtils.projectToUri(project));
+                restart(project);
             } else {
                 processDefinition(definition, "");
+                restart();
             }
             LOG.info("Added definition for " + definition);
         } else {
@@ -150,7 +155,7 @@ public class IntellijLanguageClient implements ApplicationComponent {
         }
         String projectUri = FileUtils.projectToUri(project);
         if (projectUri != null) {
-            ApplicationUtils.pool(() -> {
+            pool(() -> {
                 String ext = file.getExtension();
                 final String fileName = file.getName();
                 LOG.info("Opened " + fileName);
@@ -232,13 +237,40 @@ public class IntellijLanguageClient implements ApplicationComponent {
             return;
         }
 
-        ApplicationUtils.pool(() -> {
+        pool(() -> {
             LanguageServerWrapper serverWrapper = LanguageServerWrapper.forEditor(editor);
             if (serverWrapper != null) {
                 LOG.info("Disconnecting " + FileUtils.editorToURIString(editor));
                 serverWrapper.disconnect(editor);
             }
         });
+    }
+
+
+    /**
+     * This can be used to instantly apply a language server definition without restarting the IDE.
+     */
+    public static void restart() {
+        Project[] openProjects = ProjectManager.getInstance().getOpenProjects();
+        for (Project project : openProjects) {
+            restart(project);
+        }
+    }
+
+    /**
+     * This can be used to instantly apply a project-specific language server definition without restarting the
+     * project/IDE.
+     *
+     * @param project The project instance which need to be restarted
+     */
+    public static void restart(Project project) {
+        try {
+            List<Editor> allOpenedEditors = FileUtils.getAllOpenedEditors(project);
+            allOpenedEditors.forEach(IntellijLanguageClient::editorClosed);
+            allOpenedEditors.forEach(IntellijLanguageClient::editorClosed);
+        } catch (Exception e) {
+            LOG.warn(String.format("Refreshing project: %s is failed due to: ", project.getName()), e);
+        }
     }
 
     /**

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/LSPServerStatusWidget.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/LSPServerStatusWidget.java
@@ -125,7 +125,7 @@ public class LSPServerStatusWidget implements StatusBarWidget {
                     }
                     actions.add(new ShowTimeouts());
                     if (wrapper.isResettable()) {
-                        actions.add(new Reset());
+                        actions.add(new Restart());
                     }
 
                     String title = "Server actions";
@@ -185,15 +185,15 @@ public class LSPServerStatusWidget implements StatusBarWidget {
                 }
             }
 
-            class Reset extends AnAction implements DumbAware {
+            class Restart extends AnAction implements DumbAware {
 
-                Reset() {
-                    super("&Reset", "Reset the server so it can be started again.", null);
+                Restart() {
+                    super("&Restart", "Restarts the language server.", null);
                 }
 
                 @Override
                 public void actionPerformed(@NotNull AnActionEvent anActionEvent) {
-                    wrapper.reset();
+                    wrapper.restart();
                 }
 
             }

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/LSPServerStatusWidget.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/LSPServerStatusWidget.java
@@ -124,7 +124,7 @@ public class LSPServerStatusWidget implements StatusBarWidget {
                         actions.add(new ShowConnectedFiles());
                     }
                     actions.add(new ShowTimeouts());
-                    if (wrapper.isResettable()) {
+                    if (wrapper.isRestartable()) {
                         actions.add(new Restart());
                     }
 

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -212,7 +212,7 @@ public class LanguageServerWrapper {
                 }
             } catch (TimeoutException e) {
                 notifyFailure(INIT);
-                String msg = String.format("%s \n not initialized after %ds \n Check settings",
+                String msg = String.format("%s \n is not initialized after %d seconds",
                         serverDefinition.toString(), getTimeout(INIT) / 1000);
                 LOG.warn(msg, e);
                 invokeLater(() -> {

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -649,10 +649,10 @@ public class LanguageServerWrapper {
     }
 
     /**
-     * Is the language server in a state where it can be resettable. Normally language server is
-     * resettable if it has timeout or has a startup error.
+     * Is the language server in a state where it can be restartable. Normally language server is
+     * restartable if it has timeout or has a startup error.
      */
-    public boolean isResettable() {
+    public boolean isRestartable() {
         return status == STOPPED && (alreadyShownTimeout || alreadyShownCrash);
     }
 
@@ -660,7 +660,7 @@ public class LanguageServerWrapper {
      * Reset language server wrapper state so it can be started again if it was failed earlier.
      */
     public void restart() {
-        if (isResettable()) {
+        if (isRestartable()) {
             alreadyShownCrash = false;
             alreadyShownTimeout = false;
             IntellijLanguageClient.restart(project);

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -649,8 +649,8 @@ public class LanguageServerWrapper {
     }
 
     /**
-     * Is the langauge server in a state where it can be resettable. Normally language server is
-     * resettable if it has timedout or has a startup error.
+     * Is the language server in a state where it can be resettable. Normally language server is
+     * resettable if it has timeout or has a startup error.
      */
     public boolean isResettable() {
         return status == STOPPED && (alreadyShownTimeout || alreadyShownCrash);
@@ -659,10 +659,11 @@ public class LanguageServerWrapper {
     /**
      * Reset language server wrapper state so it can be started again if it was failed earlier.
      */
-    public void reset() {
+    public void restart() {
         if (isResettable()) {
             alreadyShownCrash = false;
             alreadyShownTimeout = false;
+            IntellijLanguageClient.restart(project);
         }
     }
 }

--- a/src/main/java/org/wso2/lsp4intellij/utils/FileUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/FileUtils.java
@@ -42,7 +42,9 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
@@ -63,6 +65,23 @@ public class FileUtils {
 
     public static String extFromPsiFile(PsiFile psiFile) {
         return psiFile.getVirtualFile().getExtension();
+    }
+
+    public static List<Editor> getAllOpenedEditors(Project project) {
+        return computableReadAction(() -> {
+            List<Editor> editors = new ArrayList<>();
+            FileEditor[] allEditors = FileEditorManager.getInstance(project).getAllEditors();
+            for (FileEditor fEditor : allEditors) {
+                if (fEditor instanceof TextEditor) {
+                    Editor editor = ((TextEditor) fEditor).getEditor();
+                    if (editor.isDisposed() || !isEditorSupported(editor)) {
+                        continue;
+                    }
+                    editors.add(editor);
+                }
+            }
+            return editors;
+        });
     }
 
     public static Editor editorFromPsiFile(PsiFile psiFile) {


### PR DESCRIPTION
## Purpose
This PR introduces language server restart support. So you can simply try to restart your failed language server using the restart action available in language server status icon.

Please refer the following example.

![Peek 2019-08-20 10-59](https://user-images.githubusercontent.com/29032600/63319988-c2c8c300-c339-11e9-806b-2d5b0e83f799.gif)

