### PR TITLE
Update symbol contributor to new API

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/contributors/symbol/LSPNavigationItem.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/symbol/LSPNavigationItem.java
@@ -24,6 +24,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import javax.swing.*;
+import java.util.Objects;
 
 /**
  * LSP implementation of NavigationItem for intellij
@@ -50,6 +51,21 @@ public class LSPNavigationItem extends OpenFileDescriptor implements NavigationI
     @Override
     public ItemPresentation getPresentation() {
         return presentation;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if(obj instanceof LSPNavigationItem) {
+            LSPNavigationItem other = (LSPNavigationItem) obj;
+            return this.getLine() == other.getLine() && this.getColumn() == other.getColumn() &&
+                    Objects.equals(this.getName(), other.getName());
+        }
+        return false;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(this.getLine(), this.getColumn(), this.getName());
     }
 
     private class LSPItemPresentation implements ItemPresentation {

--- a/src/main/java/org/wso2/lsp4intellij/contributors/symbol/LSPSymbolContributor.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/symbol/LSPSymbolContributor.java
@@ -16,30 +16,46 @@
 package org.wso2.lsp4intellij.contributors.symbol;
 
 import com.intellij.navigation.ChooseByNameContributor;
+import com.intellij.navigation.ChooseByNameContributorEx;
 import com.intellij.navigation.NavigationItem;
 import com.intellij.openapi.project.Project;
+import com.intellij.psi.search.GlobalSearchScope;
+import com.intellij.util.Processor;
+import com.intellij.util.indexing.FindSymbolParameters;
+import com.intellij.util.indexing.IdFilter;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 
 /**
  * The symbol provider implementation for LSP client.
  *
  * @author gayanper
  */
-public class LSPSymbolContributor implements ChooseByNameContributor {
+public class LSPSymbolContributor implements ChooseByNameContributorEx {
 
     private WorkspaceSymbolProvider workspaceSymbolProvider = new WorkspaceSymbolProvider();
+
+    @Override
+    public void processNames(@NotNull Processor<String> processor, @NotNull GlobalSearchScope globalSearchScope, @Nullable IdFilter idFilter) {
+        workspaceSymbolProvider.workspaceSymbols("", globalSearchScope.getProject()).stream().map(NavigationItem::getName)
+                .forEach(processor::process);
+    }
+
+    @Override
+    public void processElementsWithName(@NotNull String s, @NotNull Processor<NavigationItem> processor, @NotNull FindSymbolParameters findSymbolParameters) {
+        workspaceSymbolProvider.workspaceSymbols(s, findSymbolParameters.getProject()).forEach(processor::process);
+    }
 
     @NotNull
     @Override
     public String[] getNames(Project project, boolean includeNonProjectItems) {
-        return workspaceSymbolProvider.workspaceSymbols("", project).stream().map(NavigationItem::getName)
-                .toArray(String[]::new);
+        return null;
     }
 
     @NotNull
     @Override
     public NavigationItem[] getItemsByName(String name, String pattern, Project project,
             boolean includeNonProjectItems) {
-        return workspaceSymbolProvider.workspaceSymbols(name, project).toArray(new NavigationItem[0]);
+        return null;
     }
 }


### PR DESCRIPTION
This fixed handling of duplicate names in symbol list if two items
have the same name.

Before when we have duplicate names the items shown is 2 * number duplicates. This fixes it.