### PR TITLE
Add support for customize icons from LS client implementation.

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -33,6 +33,7 @@ import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.wso2.lsp4intellij.client.languageserver.ServerStatus;
 import org.wso2.lsp4intellij.client.languageserver.serverdefinition.LanguageServerDefinition;
 import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
@@ -370,5 +371,13 @@ public class IntellijLanguageClient implements ApplicationComponent {
     @Override
     public void disposeComponent() {
         // Todo
+    }
+
+    /**
+     * Returns the registered extension manager for this language server.
+     * @param definition The LanguageServerDefinition
+     */
+    public static Optional<LSPExtensionManager> getExtensionManagerForDefinition(@NotNull LanguageServerDefinition definition) {
+        return Optional.ofNullable(extToExtManager.get(definition.ext.split(",")[0]));
     }
 }

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/LanguageServerDefinition.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/LanguageServerDefinition.java
@@ -18,7 +18,10 @@ package org.wso2.lsp4intellij.client.languageserver.serverdefinition;
 import com.intellij.openapi.diagnostic.Logger;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.NotNull;
 import org.wso2.lsp4intellij.client.connection.StreamConnectionProvider;
+import org.wso2.lsp4intellij.contributors.icon.LSPDefaultIconProvider;
+import org.wso2.lsp4intellij.contributors.icon.LSPIconProvider;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -681,5 +681,15 @@ public class LanguageServerWrapper {
             IntellijLanguageClient.restart(project);
         }
     }
+
+    /**
+     * Returns the extension manager associated with this language server wrapper.
+     *
+     * @return The result can be null if there is not extension manager defined.
+     */
+    @Nullable
+    public final LSPExtensionManager getExtensionManager() {
+        return extManager;
+    }
 }
 

--- a/src/main/java/org/wso2/lsp4intellij/contributors/icon/LSPDefaultIconProvider.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/icon/LSPDefaultIconProvider.java
@@ -34,7 +34,7 @@ public class LSPDefaultIconProvider extends LSPIconProvider {
     private static Icon STARTING = IconLoader.getIcon("/images/starting.png");
     private static Icon STOPPED = IconLoader.getIcon("/images/stopped.png");
 
-    public static Icon getCompletionIcon(CompletionItemKind kind) {
+    public Icon getCompletionIcon(CompletionItemKind kind) {
 
         if (kind == null) {
             return null;
@@ -82,7 +82,7 @@ public class LSPDefaultIconProvider extends LSPIconProvider {
         }
     }
 
-    public static Icon getSymbolIcon(SymbolKind kind) {
+    public Icon getSymbolIcon(SymbolKind kind) {
 
         if (kind == null) {
             return null;
@@ -107,7 +107,7 @@ public class LSPDefaultIconProvider extends LSPIconProvider {
         }
     }
 
-    public static Map<ServerStatus, Icon> getStatusIcons() {
+    public Map<ServerStatus, Icon> getStatusIcons() {
         Map<ServerStatus, Icon> statusIconMap = new HashMap<>();
         statusIconMap.put(ServerStatus.STOPPED, STOPPED);
         statusIconMap.put(ServerStatus.STARTING, STARTING);

--- a/src/main/java/org/wso2/lsp4intellij/contributors/icon/LSPIconProvider.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/icon/LSPIconProvider.java
@@ -25,17 +25,11 @@ import javax.swing.*;
 
 public abstract class LSPIconProvider {
 
-    public static Icon getCompletionIcon(CompletionItemKind kind) {
-        return LSPDefaultIconProvider.getCompletionIcon(kind);
-    }
+    public abstract Icon getCompletionIcon(CompletionItemKind kind);
 
-    public static Map<ServerStatus, Icon> getStatusIcons() {
-        return LSPDefaultIconProvider.getStatusIcons();
-    }
+    public abstract Map<ServerStatus, Icon> getStatusIcons();
 
-    public static Icon getSymbolIcon(SymbolKind kind) {
-        return LSPDefaultIconProvider.getSymbolIcon(kind);
-    }
+    public abstract Icon getSymbolIcon(SymbolKind kind);
 
     public abstract boolean isSpecificFor(LanguageServerDefinition serverDefinition);
 }

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -875,7 +875,7 @@ public class EditorEventManager {
         String presentableText = StringUtils.isNotEmpty(label) ? label : (insertText != null) ? insertText : "";
         String tailText = (detail != null) ? detail : "";
         LSPIconProvider iconProvider = GUIUtils.getIconProviderFor(wrapper.getServerDefinition());
-        Icon icon = LSPIconProvider.getCompletionIcon(kind);
+        Icon icon = iconProvider.getCompletionIcon(kind);
         LookupElementBuilder lookupElementBuilder;
 
         String lookupString = null;

--- a/src/main/java/org/wso2/lsp4intellij/extensions/LSPExtensionManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/extensions/LSPExtensionManager.java
@@ -18,14 +18,18 @@ package org.wso2.lsp4intellij.extensions;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.event.DocumentListener;
 import com.intellij.openapi.editor.event.EditorMouseListener;
+import com.intellij.psi.PsiFile;
 import org.eclipse.lsp4j.ServerCapabilities;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.eclipse.lsp4j.services.LanguageServer;
+import org.jetbrains.annotations.NotNull;
 import org.wso2.lsp4intellij.client.ClientContext;
 import org.wso2.lsp4intellij.client.languageserver.ServerOptions;
 import org.wso2.lsp4intellij.client.languageserver.requestmanager.DefaultRequestManager;
 import org.wso2.lsp4intellij.client.languageserver.requestmanager.RequestManager;
 import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
+import org.wso2.lsp4intellij.contributors.icon.LSPDefaultIconProvider;
+import org.wso2.lsp4intellij.contributors.icon.LSPIconProvider;
 import org.wso2.lsp4intellij.editor.EditorEventManager;
 import org.wso2.lsp4intellij.listeners.EditorMouseMotionListenerImpl;
 
@@ -49,4 +53,14 @@ public interface LSPExtensionManager {
      * @param context The client context which can be used by the LanguageClient implementation.
      */
     LanguageClient getExtendedClientFor(ClientContext context);
+
+    /**
+     * The icon provider for the Language Server. Override and implement your own or extend the
+     * {@link LSPDefaultIconProvider} to customize the default icons.
+     *
+     */
+    @NotNull
+    default LSPIconProvider getIconProvider() {
+        return new LSPDefaultIconProvider();
+    }
 }

--- a/src/main/java/org/wso2/lsp4intellij/utils/GUIUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/GUIUtils.java
@@ -20,14 +20,17 @@ import com.intellij.codeInsight.hint.HintManagerImpl;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.ui.Hint;
 import com.intellij.ui.LightweightHint;
+import org.wso2.lsp4intellij.IntellijLanguageClient;
 import org.wso2.lsp4intellij.client.languageserver.serverdefinition.LanguageServerDefinition;
 import org.wso2.lsp4intellij.contributors.icon.LSPDefaultIconProvider;
 import org.wso2.lsp4intellij.contributors.icon.LSPIconProvider;
+import org.wso2.lsp4intellij.extensions.LSPExtensionManager;
 
 import java.awt.*;
 import javax.swing.*;
 
 public class GUIUtils {
+    private static final LSPDefaultIconProvider DEFAULT_ICON_PROVIDER = new LSPDefaultIconProvider();
 
     public static Hint createAndShowEditorHint(Editor editor, String string, Point point) {
         return createAndShowEditorHint(editor, string, point, HintManager.ABOVE,
@@ -63,6 +66,7 @@ public class GUIUtils {
      * @return The LSPIconProvider, or LSPDefaultIconProvider if none are found
      */
     public static LSPIconProvider getIconProviderFor(LanguageServerDefinition serverDefinition) {
-        return new LSPDefaultIconProvider();
+        return IntellijLanguageClient.getExtensionManagerForDefinition(serverDefinition)
+                .map(LSPExtensionManager::getIconProvider).orElse(DEFAULT_ICON_PROVIDER);
     }
 }


### PR DESCRIPTION
Add support for customize icons from LS client implementation (enhanced)

- Fix all the places where default static implementation was used for Icon
provider.
- Moved the IconProvider to ExtensionManager instead of the
ServerDefinition