### PR TITLE
Add LabelProvider for LPS elements such as symbols.

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/contributors/label/LSPDefaultLabelProvider.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/label/LSPDefaultLabelProvider.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (c) 2018-2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.contributors.label;
+
+import com.intellij.openapi.project.Project;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class LSPDefaultLabelProvider implements LSPLabelProvider {
+  @NotNull
+  @Override
+  public String symbolNameFor(@NotNull SymbolInformation symbolInformation, @NotNull Project project) {
+    return symbolInformation.getName();
+  }
+
+  @Nullable
+  @Override
+  public String symbolLocationFor(@NotNull SymbolInformation symbolInformation, @NotNull Project project) {
+    return symbolInformation.getContainerName();
+  }
+}

--- a/src/main/java/org/wso2/lsp4intellij/contributors/label/LSPLabelProvider.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/label/LSPLabelProvider.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2018-2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.contributors.label;
+
+import com.intellij.openapi.project.Project;
+import org.eclipse.lsp4j.SymbolInformation;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+/**
+ * Extension to override the default Labels for Language Server elements such as symbols and completions.
+ *
+ * @author gayanper
+ */
+public interface LSPLabelProvider {
+    /**
+     * Generate the symbol name for the given {@link SymbolInformation}.
+     */
+    @NotNull
+    String symbolNameFor(@NotNull SymbolInformation symbolInformation, @NotNull Project project);
+
+    /**
+     * Generate the symbol location for the given {@link SymbolInformation}.
+     */
+    @Nullable
+    String symbolLocationFor(@NotNull SymbolInformation symbolInformation, @NotNull Project project);
+
+}

--- a/src/main/java/org/wso2/lsp4intellij/contributors/symbol/WorkspaceSymbolProvider.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/symbol/WorkspaceSymbolProvider.java
@@ -26,7 +26,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -40,6 +39,7 @@ import org.wso2.lsp4intellij.client.languageserver.requestmanager.RequestManager
 import org.wso2.lsp4intellij.client.languageserver.serverdefinition.LanguageServerDefinition;
 import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
 import org.wso2.lsp4intellij.contributors.icon.LSPIconProvider;
+import org.wso2.lsp4intellij.contributors.label.LSPLabelProvider;
 import org.wso2.lsp4intellij.requests.Timeouts;
 import org.wso2.lsp4intellij.utils.FileUtils;
 import org.wso2.lsp4intellij.utils.GUIUtils;
@@ -71,9 +71,10 @@ public class WorkspaceSymbolProvider {
 
     if (file != null) {
       final LSPIconProvider iconProviderFor = GUIUtils.getIconProviderFor(result.getDefinition());
-      return new LSPNavigationItem(information.getName(),
-              information.getContainerName(), iconProviderFor.getSymbolIcon(information.getKind()),
-              project, file,
+      final LSPLabelProvider labelProvider = GUIUtils.getLabelProviderFor(result.getDefinition());
+      return new LSPNavigationItem(labelProvider.symbolNameFor(information, project),
+              labelProvider.symbolLocationFor(information, project), iconProviderFor.getSymbolIcon(information.getKind()),
+              project, FileUtils.URIToVFS(location.getUri()),
               location.getRange().getStart().getLine(),
               location.getRange().getStart().getCharacter());
     } else {

--- a/src/main/java/org/wso2/lsp4intellij/extensions/LSPExtensionManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/extensions/LSPExtensionManager.java
@@ -30,6 +30,8 @@ import org.wso2.lsp4intellij.client.languageserver.requestmanager.RequestManager
 import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
 import org.wso2.lsp4intellij.contributors.icon.LSPDefaultIconProvider;
 import org.wso2.lsp4intellij.contributors.icon.LSPIconProvider;
+import org.wso2.lsp4intellij.contributors.label.LSPDefaultLabelProvider;
+import org.wso2.lsp4intellij.contributors.label.LSPLabelProvider;
 import org.wso2.lsp4intellij.editor.EditorEventManager;
 import org.wso2.lsp4intellij.listeners.EditorMouseMotionListenerImpl;
 
@@ -77,4 +79,14 @@ public interface LSPExtensionManager {
     default boolean isFileContentSupported(@NotNull PsiFile file) {
         return true;
     }
+
+    /**
+     * The label provider for the Language Server. Implement and override default behavior
+     * if it needs to be customize.
+     */
+    @NotNull
+    default LSPLabelProvider getLabelProvider() {
+        return new LSPDefaultLabelProvider();
+    }
+
 }

--- a/src/main/java/org/wso2/lsp4intellij/utils/GUIUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/GUIUtils.java
@@ -24,13 +24,17 @@ import org.wso2.lsp4intellij.IntellijLanguageClient;
 import org.wso2.lsp4intellij.client.languageserver.serverdefinition.LanguageServerDefinition;
 import org.wso2.lsp4intellij.contributors.icon.LSPDefaultIconProvider;
 import org.wso2.lsp4intellij.contributors.icon.LSPIconProvider;
+import org.wso2.lsp4intellij.contributors.label.LSPDefaultLabelProvider;
 import org.wso2.lsp4intellij.extensions.LSPExtensionManager;
+import org.wso2.lsp4intellij.contributors.label.LSPLabelProvider;
 
 import java.awt.*;
 import javax.swing.*;
 
 public class GUIUtils {
     private static final LSPDefaultIconProvider DEFAULT_ICON_PROVIDER = new LSPDefaultIconProvider();
+
+    private static final LSPLabelProvider DEFAULT_LABEL_PROVIDER = new LSPDefaultLabelProvider();
 
     public static Hint createAndShowEditorHint(Editor editor, String string, Point point) {
         return createAndShowEditorHint(editor, string, point, HintManager.ABOVE,
@@ -69,4 +73,16 @@ public class GUIUtils {
         return IntellijLanguageClient.getExtensionManagerForDefinition(serverDefinition)
                 .map(LSPExtensionManager::getIconProvider).orElse(DEFAULT_ICON_PROVIDER);
     }
+
+    /**
+     * Returns a suitable LSPLabelProvider given a ServerDefinition
+     *
+     * @param serverDefinition The serverDefinition
+     * @return The LSPLabelProvider, or the default if none are found
+     */
+    public static LSPLabelProvider getLabelProviderFor(LanguageServerDefinition serverDefinition) {
+        return IntellijLanguageClient.getExtensionManagerForDefinition(serverDefinition)
+                .map(LSPExtensionManager::getLabelProvider).orElse(DEFAULT_LABEL_PROVIDER);
+    }
+
 }


### PR DESCRIPTION
The default label provider is used by when no custom label
provider is provided.