### PR TITLE
Add support for quick doc hovers (support for opening files)

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -15,6 +15,9 @@
  */
 package org.wso2.lsp4intellij.editor;
 
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
 import com.intellij.codeInsight.completion.InsertionContext;
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
 import com.intellij.codeInsight.hint.HintManager;
@@ -82,10 +85,7 @@ import java.awt.Cursor;
 import java.awt.Point;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -255,9 +255,8 @@ public class EditorEventManager {
             return;
         }
         Language language = psiFile.getLanguage();
-        if ((!LanguageDocumentation.INSTANCE.allForLanguage(language).isEmpty() && !language
-                .equals(PlainTextLanguage.INSTANCE)) || (!getIsCtrlDown() && !EditorSettingsExternalizable
-                .getInstance().isShowQuickDocOnMouseOverElement())) {
+        if ((!LanguageDocumentation.INSTANCE.allForLanguage(language).isEmpty() && !isSupportedLanguageFile(psiFile))
+                || (!getIsCtrlDown() && !EditorSettingsExternalizable.getInstance().isShowQuickDocOnMouseOverElement())) {
             return;
         }
 
@@ -295,6 +294,11 @@ public class EditorEventManager {
             }
             predTime = curTime;
         }
+    }
+
+    private boolean isSupportedLanguageFile(PsiFile file) {
+        return file.getLanguage().isKindOf(PlainTextLanguage.INSTANCE)
+            || FileUtils.isFileSupported(file.getVirtualFile());
     }
 
     /**

--- a/src/main/java/org/wso2/lsp4intellij/requests/HoverHandler.java
+++ b/src/main/java/org/wso2/lsp4intellij/requests/HoverHandler.java
@@ -47,28 +47,27 @@ public class HoverHandler {
         }
         Either<List<Either<String, MarkedString>>, MarkupContent> hoverContents = hover.getContents();
         if (hoverContents.isLeft()) {
-            boolean useHtml = false;
             List<Either<String, MarkedString>> contents = hoverContents.getLeft();
             if (contents != null && !contents.isEmpty()) {
                 List<String> result = new ArrayList<>();
                 for (Either<String, MarkedString> c : contents) {
+                    String string = "";
                     if (c.isLeft() && !c.getLeft().isEmpty()) {
-                        result.add(c.getLeft());
+                        string = c.getLeft();
                     } else if (c.isRight()) {
-                        useHtml = true;
-                        MutableDataSet options = new MutableDataSet();
-                        Parser parser = Parser.builder(options).build();
-                        HtmlRenderer renderer = HtmlRenderer.builder(options).build();
                         MarkedString markedString = c.getRight();
-                        String string = (markedString.getLanguage() != null && !markedString.getLanguage().isEmpty()) ?
+                        string = (markedString.getLanguage() != null && !markedString.getLanguage().isEmpty()) ?
                                 "```" + markedString.getLanguage() + " " + markedString.getValue() + "```" :
                                 "";
-                        if (!string.isEmpty()) {
-                            result.add(renderer.render(parser.parse(string)));
-                        }
+                    }
+                    MutableDataSet options = new MutableDataSet();
+                    Parser parser = Parser.builder(options).build();
+                    HtmlRenderer renderer = HtmlRenderer.builder(options).build();
+                    if (!string.isEmpty()) {
+                        result.add(renderer.render(parser.parse(string)));
                     }
                 }
-                return useHtml ? "<html>" + String.join("\n\n", result) + "</html>" : String.join("\n\n", result);
+                return "<html>" + String.join("\n\n", result) + "</html>";
             } else {
                 return "";
             }


### PR DESCRIPTION
- enabled HTML formatting for all content since LSP spec is now sending
markup content
- use a textpane with JB html kit to style the documentation
- add support for lanuguage like java which doesn't inherit from plain
text language.
- add support for open source files from links in quick doc hover

![quick-docs](https://user-images.githubusercontent.com/7471994/67690811-92e60d80-f9c3-11e9-944c-5e265af1bd86.gif)
