### PR TITLE
Add support for file content based connection to LS

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -90,12 +90,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -111,6 +106,7 @@ import static org.wso2.lsp4intellij.client.languageserver.ServerStatus.STOPPED;
 import static org.wso2.lsp4intellij.requests.Timeout.getTimeout;
 import static org.wso2.lsp4intellij.requests.Timeouts.INIT;
 import static org.wso2.lsp4intellij.requests.Timeouts.SHUTDOWN;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableReadAction;
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeLater;
 import static org.wso2.lsp4intellij.utils.FileUtils.editorToProjectFolderUri;
 import static org.wso2.lsp4intellij.utils.FileUtils.editorToURIString;
@@ -351,7 +347,7 @@ public class LanguageServerWrapper {
                         }
                         // trigger annotators since the this is the first editor which starts the LS
                         // and annotators are executed before LS is boostrap to provide diagnostics
-                        ApplicationUtils.computableReadAction(() -> {
+                        computableReadAction(() -> {
                             DaemonCodeAnalyzer.getInstance(project).restart(
                                     PsiDocumentManager.getInstance(project).getPsiFile(editor.getDocument()));
                             return null;

--- a/src/main/java/org/wso2/lsp4intellij/extensions/LSPExtensionManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/extensions/LSPExtensionManager.java
@@ -63,4 +63,18 @@ public interface LSPExtensionManager {
     default LSPIconProvider getIconProvider() {
         return new LSPDefaultIconProvider();
     }
+
+    /**
+     * Some language servers might only need to start for files which has a specific content. This method can be used
+     * in such situation to control whether the file must be connected to a language server which is registered for the
+     * extension of this file.
+     *
+     * <b>Note:</b> By default this method returns <code>true</code>
+     *
+     * @param file PsiFile which is about to connect to a language server.
+     * @return <code>true</code> if the file is supported.
+     */
+    default boolean isFileContentSupported(@NotNull PsiFile file) {
+        return true;
+    }
 }


### PR DESCRIPTION
This change introduce a new method in LSPExtensionManager so that
implementors can use to control which files should be connected to LS
based on their content or PsiFIle Language.

