### PR TITLE
fix rename bug, editor does not hasFocus when using rename from menu

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/contributors/rename/LSPRenameHandler.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/rename/LSPRenameHandler.java
@@ -66,13 +66,13 @@ public class LSPRenameHandler implements RenameHandler {
     public void invoke(@NotNull Project project, Editor editor, PsiFile file, DataContext dataContext) {
         EditorEventManager manager = EditorEventManagerBase.forEditor(editor);
         if (manager != null) {
-            if (editor.getContentComponent().hasFocus()) {
-                LSPPsiElement psiElement = getElementAtOffset(manager,
-                        editor.getCaretModel().getCurrentCaret().getOffset());
-                if (psiElement != null) {
-                    doRename(psiElement, editor);
-                }
+            // if (editor.getContentComponent().hasFocus()) {
+            LSPPsiElement psiElement = getElementAtOffset(manager,
+                editor.getCaretModel().getCurrentCaret().getOffset());
+            if (psiElement != null) {
+                doRename(psiElement, editor);
             }
+            // }
         }
     }
 

--- a/src/main/java/org/wso2/lsp4intellij/contributors/rename/LSPRenameHandler.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/rename/LSPRenameHandler.java
@@ -66,13 +66,11 @@ public class LSPRenameHandler implements RenameHandler {
     public void invoke(@NotNull Project project, Editor editor, PsiFile file, DataContext dataContext) {
         EditorEventManager manager = EditorEventManagerBase.forEditor(editor);
         if (manager != null) {
-            // if (editor.getContentComponent().hasFocus()) {
             LSPPsiElement psiElement = getElementAtOffset(manager,
                 editor.getCaretModel().getCurrentCaret().getOffset());
             if (psiElement != null) {
                 doRename(psiElement, editor);
             }
-            // }
         }
     }
 


### PR DESCRIPTION
## Purpose
> 1. Fix the bug of doing nothing when using rename from menu ( or popup menu) Refactor->Rename.  Please check the attached gif. The first rename was done by Shift+F6
![lsp-rename-bug](https://user-images.githubusercontent.com/6220120/66834630-983d6400-ef90-11e9-9bef-2c84d77dcf2b.gif)

## Goals
> if the user click rename from menu, our plugin will do the rename

## Approach
> When using rename from menu, the editor lost focus, so this line below will be false. It is easy to find out when debugging the code
`if (editor.getContentComponent().hasFocus())`

## Test environment
> openjdk version "11.0.3" 2019-04-16
OpenJDK Runtime Environment (build 11.0.3+12-b304.10)
OpenJDK 64-Bit Server VM (build 11.0.3+12-b304.10, mixed mode)

$ ./clangd --version
clangd version 8.0.0 (tags/RELEASE_800/final)
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.