### PR TITLE
[BUG] fix the invalid path bug, the uri maybe null when the path is i…

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
@@ -92,7 +92,7 @@ public class EditorEventManagerBase {
      */
     public static EditorEventManager forUri(String uri) {
         prune();
-        return uriToManager.get(uri);
+        return uri == null ? null : uriToManager.get(uri);
     }
 
     private static void prune() {


### PR DESCRIPTION
## Purpose
> when the file path is invalid, the lsp plugin would give and null point exception.
![image](https://user-images.githubusercontent.com/22075197/67005052-4cb3c300-f114-11e9-8f97-d56f9320807c.png)


## Goals
> add null check for URI, so the plugin would not give the nullpointer exception

## Approach
> add null check for URI
```
return uri == null ? null : uriToManager.get(uri);
```

## Test environment
> OpenJDK Version: "1.8.0_222"
> Ubuntu 16.04