### PR TITLE
LSPCommandFix should be enabled

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/contributors/fixes/LSPCommandFix.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/fixes/LSPCommandFix.java
@@ -54,7 +54,7 @@ public class LSPCommandFix implements IntentionAction {
 
     @Override
     public boolean isAvailable(@NotNull Project project, Editor editor, PsiFile psiFile) {
-        return false;
+        return true;
     }
 
     @Override


### PR DESCRIPTION
## Purpose
> Our plugin could not show quick fix from clangd with LSPCommandFix disabled

## Goals
> After I enabled it, quick fix (Alt+Enter) is ok now. 

## Test environment
> openjdk version "11.0.3" 2019-04-16
OpenJDK Runtime Environment (build 11.0.3+12-b304.10)
OpenJDK 64-Bit Server VM (build 11.0.3+12-b304.10, mixed mode)
$ ./clangd --version
clangd version 8.0.0 (tags/RELEASE_800/final)
 