### PR TITLE
Fix random error in 2019.3

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/utils/ApplicationUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/ApplicationUtils.java
@@ -16,7 +16,11 @@
 package org.wso2.lsp4intellij.utils;
 
 import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.application.ModalityState;
+import com.intellij.openapi.project.NoAccessDuringPsiEvents;
 import com.intellij.openapi.util.Computable;
+import com.intellij.openapi.util.Condition;
+
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -55,5 +59,17 @@ public class ApplicationUtils {
 
     static public <T> T computableWriteAction(Computable<T> computable) {
         return ApplicationManager.getApplication().runWriteAction(computable);
+    }
+
+    static public void invokeAfterPsiEvents(Runnable runnable) {
+        Runnable wrapper = () -> {
+            if(NoAccessDuringPsiEvents.isInsideEventProcessing()) {
+                invokeAfterPsiEvents(runnable);
+            } else {
+                runnable.run();
+            }
+        };
+
+        ApplicationManager.getApplication().invokeLater(wrapper, (Condition<Void>) value -> false);
     }
 }


### PR DESCRIPTION
This fix will make sure the file index is not accessed while PSI file
 events are being processed. This is a prohibited action in 2019.3

