### PR TITLE
Fixed compatibility issues with upcoming IJ release

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/contributors/icon/LSPDefaultIconProvider.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/icon/LSPDefaultIconProvider.java
@@ -43,12 +43,8 @@ public class LSPDefaultIconProvider extends LSPIconProvider {
         switch (kind) {
             case Class:
                 return Nodes.Class;
-            case Color:
-                return null;
-            case Constructor:
-                return null;
             case Enum:
-                return Nodes.Class;
+                return Nodes.Enum;
             case Field:
                 return Nodes.Field;
             case File:
@@ -73,8 +69,6 @@ public class LSPDefaultIconProvider extends LSPIconProvider {
                 return AllIcons.FileTypes.Text;
             case Unit:
                 return Nodes.Artifact;
-            case Value:
-                return Nodes.DataSource;
             case Variable:
                 return Nodes.Variable;
             default:


### PR DESCRIPTION
Fix for the following compatibility issue
```
Compatibility problems (1): 
    #Access to unresolved field com.intellij.icons.AllIcons.Nodes.DataSource : Icon
        Method org.wso2.lsp4intellij.contributors.icon.LSPDefaultIconProvider.getCompletionIcon(org.eclipse.lsp4j.CompletionItemKind kind) : javax.swing.Icon contains a *getstatic* instruction referencing an unresolved field com.intellij.icons.AllIcons.Nodes.DataSource : javax.swing.Icon. This can lead to **NoSuchFieldError** exception at runtime.
```
When verified against: IC-201.6668.121