### PR TITLE
Update for IDEA 2020.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ group = "org.wso2.lsp4intellij"
 version = gitVersionCalculator.calculateVersion("v")
 
 intellij {
-    version '2017.3'
+    version '2020.1'
     type 'IC'
     updateSinceUntilBuild false
 }

--- a/src/main/java/org/wso2/lsp4intellij/contributors/psi/LSPPsiElement.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/psi/LSPPsiElement.java
@@ -358,6 +358,7 @@ public class LSPPsiElement implements PsiNameIdentifierOwner, NavigatablePsiElem
      * @throws IncorrectOperationException if the modification is not supported or not possible for some reason.
      * @deprecated not all PSI implementations implement this method correctly.
      */
+    @Deprecated
     public void checkAdd(PsiElement element) {
         throw new IncorrectOperationException();
     }
@@ -417,6 +418,7 @@ public class LSPPsiElement implements PsiNameIdentifierOwner, NavigatablePsiElem
      * @throws IncorrectOperationException if the modification is not supported or not possible for some reason.
      * @deprecated not all PSI implementations implement this method correctly.
      */
+    @Deprecated
     public void checkDelete() {
         throw new IncorrectOperationException();
     }

--- a/src/main/java/org/wso2/lsp4intellij/contributors/symbol/LSPSymbolContributor.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/symbol/LSPSymbolContributor.java
@@ -32,10 +32,10 @@ import org.jetbrains.annotations.Nullable;
  */
 public class LSPSymbolContributor implements ChooseByNameContributorEx {
 
-    private WorkspaceSymbolProvider workspaceSymbolProvider = new WorkspaceSymbolProvider();
+    private final WorkspaceSymbolProvider workspaceSymbolProvider = new WorkspaceSymbolProvider();
 
     @Override
-    public void processNames(@NotNull Processor<String> processor, @NotNull GlobalSearchScope globalSearchScope, @Nullable IdFilter idFilter) {
+    public void processNames(@NotNull Processor<? super String> processor, @NotNull GlobalSearchScope globalSearchScope, @Nullable IdFilter idFilter) {
         workspaceSymbolProvider.workspaceSymbols("", globalSearchScope.getProject()).stream()
             .filter(ni -> globalSearchScope.accept(ni.getFile()))
             .map(NavigationItem::getName)
@@ -43,22 +43,9 @@ public class LSPSymbolContributor implements ChooseByNameContributorEx {
     }
 
     @Override
-    public void processElementsWithName(@NotNull String s, @NotNull Processor<NavigationItem> processor, @NotNull FindSymbolParameters findSymbolParameters) {
+    public void processElementsWithName(@NotNull String s, @NotNull Processor<? super NavigationItem> processor, @NotNull FindSymbolParameters findSymbolParameters) {
         workspaceSymbolProvider.workspaceSymbols(s, findSymbolParameters.getProject()).stream()
             .filter(ni -> findSymbolParameters.getSearchScope().accept(ni.getFile()))
             .forEach(processor::process);
-    }
-
-    @NotNull
-    @Override
-    public String[] getNames(Project project, boolean includeNonProjectItems) {
-        return null;
-    }
-
-    @NotNull
-    @Override
-    public NavigationItem[] getItemsByName(String name, String pattern, Project project,
-            boolean includeNonProjectItems) {
-        return null;
     }
 }


### PR DESCRIPTION
This updates the build to target IDEA 2020.1. I'm not sure if we want to leave the `build.gradle` as-is or update it to 2020.1 as I have in this PR. There's certainly value in updating it to verify that the build actually compiles with a recent version of IntelliJ. If we want to ensure cross-IntelliJ compatiblity, we should probably update the CI job to deal with that in some way.

I've titled this PR as `WIP` as the `FileUtilsTest` is failing for me. However, HEAD doesn't build for me for other reasons, so if it passes on CI I'd be ok with moving forward.

```
> Task :test

org.wso2.lsp4intellij.utils.FileUtilsTest > initializationError FAILED
    org.objenesis.ObjenesisException
        Caused by: java.lang.reflect.InvocationTargetException
            Caused by: java.lang.IllegalAccessError

9 tests completed, 1 failed
```