### PR TITLE
Null-safe Optional

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -95,6 +95,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -196,18 +197,11 @@ public class LanguageServerWrapper {
      * @return if the server supports willSaveWaitUntil
      */
     public boolean isWillSaveWaitUntil() {
-        ServerCapabilities serverCapabilities = getServerCapabilities();
-        Either<TextDocumentSyncKind, TextDocumentSyncOptions> capabilities =
-                serverCapabilities != null ? serverCapabilities.getTextDocumentSync() : null;
-        if (capabilities == null) {
-            return false;
-        }
-        if (capabilities.isLeft()) {
-            return false;
-        } else {
-            final Boolean res = capabilities.getRight().getWillSaveWaitUntil();
-            return res == null ? false : res;
-        }
+        return Optional.ofNullable(getServerCapabilities())
+          .map(ServerCapabilities::getTextDocumentSync)
+          .map(Either::getRight)
+          .map(TextDocumentSyncOptions::getWillSaveWaitUntil)
+          .orElse(false);
     }
 
     /**


### PR DESCRIPTION
## Purpose
> Describe the problems, issues, or needs driving this feature/fix and include links to related issues in the following format: Resolves issue1, issue2, etc.

isWillSaveWaitUntil uses many methods that may return nulls and a lot of null-checks. Let's move this null-check to java8 Optional feature.

## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

Reduce NPEs