### PR TITLE
Make LSPAnnotator more extensible

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
@@ -36,7 +36,7 @@ import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
 import java.util.List;
 
-public class LSPAnnotator extends ExternalAnnotator {
+public class LSPAnnotator extends ExternalAnnotator<Object, Object> {
 
     private static final Logger LOG = Logger.getInstance(LSPAnnotator.class);
     private static final Object RESULT = new Object();
@@ -110,6 +110,7 @@ public class LSPAnnotator extends ExternalAnnotator {
             return;
         }
         annotations.forEach(annotation -> {
+            // TODO: Use 'newAnnotation'; 'createAnnotation' is deprecated.
             Annotation anon = holder.createAnnotation(annotation.getSeverity(),
                     new TextRange(annotation.getStartOffset(), annotation.getEndOffset()), annotation.getMessage());
 
@@ -120,11 +121,25 @@ public class LSPAnnotator extends ExternalAnnotator {
         });
     }
 
-    /**
-     * This can be overridden to modify an annotation after it has been created.
-     * Useful for customizing highlighting beyond what LSP supports.
-     */
-    protected void modifyCreatedAnnotation(@SuppressWarnings("unused") Annotation annotation) {
+    @Nullable
+    protected Annotation createAnnotation(Editor editor, AnnotationHolder holder, Diagnostic diagnostic) {
+        final int start = DocumentUtils.LSPPosToOffset(editor, diagnostic.getRange().getStart());
+        final int end = DocumentUtils.LSPPosToOffset(editor, diagnostic.getRange().getEnd());
+        if (start >= end) {
+            return null;
+        }
+        final TextRange textRange = new TextRange(start, end);
+        switch (diagnostic.getSeverity()) {
+            // TODO: Use 'newAnnotation'; 'create*Annotation' methods are deprecated.
+            case Error:
+                return holder.createErrorAnnotation(textRange, diagnostic.getMessage());
+            case Warning:
+                return holder.createWarningAnnotation(textRange, diagnostic.getMessage());
+            case Information:
+                return holder.createInfoAnnotation(textRange, diagnostic.getMessage());
+            default:
+                return holder.createWeakWarningAnnotation(textRange, diagnostic.getMessage());
+        }
     }
 
     private void createAnnotations(AnnotationHolder holder, EditorEventManager eventManager) {
@@ -133,32 +148,10 @@ public class LSPAnnotator extends ExternalAnnotator {
 
         List<Annotation> annotations = new ArrayList<>();
         diagnostics.forEach(d -> {
-            final int start = DocumentUtils.LSPPosToOffset(editor, d.getRange().getStart());
-            final int end = DocumentUtils.LSPPosToOffset(editor, d.getRange().getEnd());
-
-            if (start >= end) {
-                return;
+            Annotation annotation = createAnnotation(editor, holder, d);
+            if (annotation != null) {
+                annotations.add(annotation);
             }
-
-            Annotation annotation;
-            final TextRange textRange = new TextRange(start, end);
-            switch (d.getSeverity()) {
-                case Error:
-                    annotation = holder.createErrorAnnotation(textRange, d.getMessage());
-                    break;
-                case Warning:
-                    annotation = holder.createWarningAnnotation(textRange, d.getMessage());
-                    break;
-                case Information:
-                    annotation = holder.createInfoAnnotation(textRange, d.getMessage());
-                    break;
-                default:
-                    annotation = holder.createWeakWarningAnnotation(textRange, d.getMessage());
-                    break;
-            }
-
-            modifyCreatedAnnotation(annotation);
-            annotations.add(annotation);
         });
 
         eventManager.setAnnotations(annotations);

--- a/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
@@ -120,6 +120,13 @@ public class LSPAnnotator extends ExternalAnnotator {
         });
     }
 
+    /**
+     * This can be overridden to modify an annotation after it has been created.
+     * Useful for customizing highlighting beyond what LSP supports.
+     */
+    protected void modifyCreatedAnnotation(@SuppressWarnings("unused") Annotation annotation) {
+    }
+
     private void createAnnotations(AnnotationHolder holder, EditorEventManager eventManager) {
         final List<Diagnostic> diagnostics = eventManager.getDiagnostics();
         final Editor editor = eventManager.editor;
@@ -150,6 +157,7 @@ public class LSPAnnotator extends ExternalAnnotator {
                     break;
             }
 
+            modifyCreatedAnnotation(annotation);
             annotations.add(annotation);
         });
 


### PR DESCRIPTION
I'm not sure if this is the right way to go about this, but we likely want some way of customizing the highlighting of LSPAnnotator. Extending LSPAnnotator and customizing its behavior with this new method, `modifyCreatedAnnotation()`, seems to make this work quite easily. Though, again, I'm open to a better way of accomplishing this.

For context, here is how I'm using this -

```scala
class HaskForceLSPAnnotator extends LSPAnnotator {

  override def modifyCreatedAnnotation(annotation: Annotation): Unit = {
    GhcMessageType.of(annotation.getMessage).foreach {
      case GhcMessageType.NotInScope =>
        annotation.setHighlightType(ProblemHighlightType.LIKE_UNKNOWN_SYMBOL)
      case GhcMessageType.CouldNotFindModule =>
        annotation.setHighlightType(ProblemHighlightType.LIKE_UNKNOWN_SYMBOL)
    }
  }
}
```