### PR TITLE
Do not reopen files when writable status changes

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/listeners/LSPFileEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/listeners/LSPFileEventManager.java
@@ -202,14 +202,14 @@ class LSPFileEventManager {
                                 wrapper.disconnect(oldFileUri, FileUtils.projectToUri(p));
                             });
                         }
-
-                        // Todo - Stop opening files with the same file name.
-                        // Re-open file to so that the new editor will be connected to the language server.
-                        FileEditorManager fileEditorManager = FileEditorManager.getInstance(p);
-                        ApplicationUtils.invokeLater(() -> {
-                            fileEditorManager.closeFile(file);
-                            fileEditorManager.openFile(file, true);
-                        });
+                        if (!newFileUri.equals(oldFileUri)) {
+                            // Re-open file to so that the new editor will be connected to the language server.
+                            FileEditorManager fileEditorManager = FileEditorManager.getInstance(p);
+                            ApplicationUtils.invokeLater(() -> {
+                                fileEditorManager.closeFile(file);
+                                fileEditorManager.openFile(file, true);
+                            });
+                        }
                     });
                 }
             } catch (Exception e) {


### PR DESCRIPTION
It is not necessary to open the editor when the file changes the writable status, prevent this to happen when the file uri doesn't change

## Purpose
> If your lsp protocol changes the writable status of specific files, IntelliJ opens one editor per file changed. This is very annoying for the users

## Goals
> Check if the file name change before opening the editor

## Approach
> n/a

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> N/A bug fixed, no user experience changed

## Training
> 
## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> Not tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.