### PR TITLE
fix NPE #210 and respond according to spec; propose less intrusive showMessage/Request() ui

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
@@ -158,8 +158,10 @@ public class DefaultLanguageClient implements LanguageClient {
 
 
         List<String> options = new ArrayList<>();
-        for (MessageActionItem item : actions) {
-            options.add(item.getTitle());
+        if (actions != null) {
+            for (MessageActionItem item : actions) {
+                options.add(item.getTitle());
+            }
         }
 
         Integer exitCode;

--- a/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
@@ -152,16 +152,13 @@ public class DefaultLanguageClient implements LanguageClient {
     @Override
     public CompletableFuture<MessageActionItem> showMessageRequest(ShowMessageRequestParams showMessageRequestParams) {
         List<MessageActionItem> actions = showMessageRequestParams.getActions();
-        String title = "Language Server message";
+        String title = "Language Server " + showMessageRequestParams.getType().toString();
         String message = showMessageRequestParams.getMessage();
         MessageType msgType = showMessageRequestParams.getType();
 
-
-        List<String> options = new ArrayList<>();
-        if (actions != null) {
-            for (MessageActionItem item : actions) {
-                options.add(item.getTitle());
-            }
+        String[] options = new String[actions == null ? 0 : actions.size()];
+        for (int i = 0, size = options.length; i < size; i++) {
+            options[i] = actions.get(i).getTitle();
         }
 
         Integer exitCode;
@@ -182,7 +179,7 @@ public class DefaultLanguageClient implements LanguageClient {
             }
 
             task = new FutureTask<>(
-                    () -> Messages.showDialog(message, title, (String[]) options.toArray(), 0, icon));
+                    () -> Messages.showDialog(message, title, options, 0, icon));
             ApplicationManager.getApplication().invokeAndWait(task);
 
             try {
@@ -194,11 +191,11 @@ public class DefaultLanguageClient implements LanguageClient {
 
         } else {
 
-            final Notification notification = STICKY_NOTIFICATION_GROUP.createNotification(title, "subtitle", message, getNotificationType(msgType));
+            final Notification notification = STICKY_NOTIFICATION_GROUP.createNotification(title, null, message, getNotificationType(msgType));
             final CompletableFuture<Integer> integerCompletableFuture = new CompletableFuture<>();
-            for (int i = 0, optionsSize = options.size(); i < optionsSize; i++) {
+            for (int i = 0, optionsSize = options.length; i < optionsSize; i++) {
                 int finalI = i;
-                notification.addAction(new NotificationAction(options.get(finalI)) {
+                notification.addAction(new NotificationAction(options[i]) {
                     @Override
                     public boolean isDumbAware() {
                         return true;

--- a/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
@@ -225,7 +225,7 @@ public class DefaultLanguageClient implements LanguageClient {
                 exitCode = -1;
             }
         }
-        return CompletableFuture.completedFuture(exitCode < 0 ? null : new MessageActionItem(actions.get(exitCode).getTitle()));
+        return CompletableFuture.completedFuture(actions == null || exitCode < 0 ? null : actions.get(exitCode));
     }
 
     @NotNull

--- a/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
@@ -48,8 +48,7 @@ public class DefaultLanguageClient implements LanguageClient {
     final private Map<String, DynamicRegistrationMethods> registrations = new ConcurrentHashMap<>();
     @NotNull
     private final ClientContext context;
-    private boolean isModal = false;
-
+    protected boolean isModal = false;
 
     public DefaultLanguageClient(@NotNull ClientContext context) {
         this.context = context;
@@ -105,7 +104,6 @@ public class DefaultLanguageClient implements LanguageClient {
         LOG.info(o.toString());
     }
 
-
     @Override
     public void publishDiagnostics(PublishDiagnosticsParams publishDiagnosticsParams) {
         String uri = FileUtils.sanitizeURI(publishDiagnosticsParams.getUri());
@@ -125,11 +123,11 @@ public class DefaultLanguageClient implements LanguageClient {
             ApplicationUtils.invokeLater(() -> {
                 MessageType msgType = messageParams.getType();
                 switch (msgType) {
-                    case Warning:
-                        Messages.showWarningDialog(message, title);
-                        break;
                     case Error:
                         Messages.showErrorDialog(message, title);
+                        break;
+                    case Warning:
+                        Messages.showWarningDialog(message, title);
                         break;
                     case Info:
                     case Log:
@@ -140,7 +138,6 @@ public class DefaultLanguageClient implements LanguageClient {
                         break;
                 }
             });
-
         } else {
             NotificationType type = getNotificationType(messageParams.getType());
             final Notification notification = new Notification(
@@ -161,21 +158,25 @@ public class DefaultLanguageClient implements LanguageClient {
             options[i] = actions.get(i).getTitle();
         }
 
-        Integer exitCode;
+        int exitCode;
         FutureTask<Integer> task;
         if (isModal) {
             Icon icon;
-            if (msgType == MessageType.Error) {
-                icon = UIUtil.getErrorIcon();
-            } else if (msgType == MessageType.Warning) {
-                icon = UIUtil.getWarningIcon();
-            } else if (msgType == MessageType.Info) {
-                icon = UIUtil.getInformationIcon();
-            } else if (msgType == MessageType.Log) {
-                icon = UIUtil.getInformationIcon();
-            } else {
-                icon = null;
-                LOG.warn("No message type for " + message);
+            switch (msgType) {
+                case Error:
+                    icon = UIUtil.getErrorIcon();
+                    break;
+                case Warning:
+                    icon = UIUtil.getWarningIcon();
+                    break;
+                case Info:
+                case Log:
+                    icon = UIUtil.getInformationIcon();
+                    break;
+                default:
+                    icon = null;
+                    LOG.warn("No message type for " + message);
+                    break;
             }
 
             task = new FutureTask<>(
@@ -229,11 +230,11 @@ public class DefaultLanguageClient implements LanguageClient {
     protected NotificationType getNotificationType(@NotNull MessageType messageType) {
         NotificationType type;
         switch (messageType) {
-            case Warning:
-                type = NotificationType.WARNING;
-                break;
             case Error:
                 type = NotificationType.ERROR;
+                break;
+            case Warning:
+                type = NotificationType.WARNING;
                 break;
             case Info:
             case Log:
@@ -250,20 +251,25 @@ public class DefaultLanguageClient implements LanguageClient {
         String message = messageParams.getMessage();
         MessageType msgType = messageParams.getType();
 
-        if (msgType == MessageType.Error) {
-            LOG.error(message);
-        } else if (msgType == MessageType.Warning) {
-            LOG.warn(message);
-        } else if (msgType == MessageType.Info) {
-            LOG.info(message);
-        }else if (msgType == MessageType.Log) {
-            LOG.debug(message);
-        } else {
-            LOG.warn("Unknown message type '" + msgType + "' for " + message);
+        switch (msgType) {
+            case Error:
+                LOG.error(message);
+                break;
+            case Warning:
+                LOG.warn(message);
+                break;
+            case Info:
+            case Log:
+                LOG.info(message);
+                break;
+            default:
+                LOG.warn("Unknown message type '" + msgType + "' for " + message);
+                break;
         }
     }
 
-    protected final @NotNull ClientContext getContext() {
+    @NotNull
+    protected final ClientContext getContext() {
         return context;
     }
 

--- a/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
@@ -226,25 +226,18 @@ public class DefaultLanguageClient implements LanguageClient {
         return CompletableFuture.completedFuture(actions == null || exitCode < 0 ? null : actions.get(exitCode));
     }
 
-    @NotNull
     protected NotificationType getNotificationType(@NotNull MessageType messageType) {
-        NotificationType type;
         switch (messageType) {
             case Error:
-                type = NotificationType.ERROR;
-                break;
+                return NotificationType.ERROR;
             case Warning:
-                type = NotificationType.WARNING;
-                break;
+                return NotificationType.WARNING;
             case Info:
             case Log:
             default:
-                type = NotificationType.INFORMATION;
-                break;
+                return NotificationType.INFORMATION;
         }
-        return type;
     }
-
 
     @Override
     public void logMessage(MessageParams messageParams) {


### PR DESCRIPTION

## Purpose
1. closes #210 - checks whether actions are received (i.e. are null) and not assuming that returns an empty list
2. responds with null if the dialog/notification is closed without a choosing an action - according to LSP Spec (3.15).
3. Additionally this PR introduces the ability to make showMessage/+Request less intrusive via non-modal Notifications.

