### PR TITLE
Enhancement: Starting connections without opening an Editor first

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -94,8 +94,11 @@ public class IntellijLanguageClient implements ApplicationComponent, Disposable 
     public void initProjectConnections(@NotNull Project project) {
         String projectStr = FileUtils.projectToUri(project);
         // find serverdefinition keys for this project and try to start a wrapper
-        extToServerDefinition.entrySet().stream().filter((e) -> e.getKey().getRight().equals(projectStr)).forEach(entry -> {
-            updateLanguageWrapperContainers(project, entry.getKey(), entry.getValue()).start();
+        extToServerDefinition.entrySet().stream().filter(e -> e.getKey().getRight().equals(projectStr)).forEach(entry -> {
+            final LanguageServerWrapper wrapper = addLanguageServerWrapper(project, entry.getKey(), entry.getValue());
+            if (wrapper != null) {
+                wrapper.start();
+            }
         });
 
     }
@@ -243,14 +246,17 @@ public class IntellijLanguageClient implements ApplicationComponent, Disposable 
                 return;
             }
             // Update project mapping for language servers.
-            LanguageServerWrapper wrapper = updateLanguageWrapperContainers(project, new ImmutablePair<>(ext, projectUri), serverDefinition);
+            LanguageServerWrapper wrapper = addLanguageServerWrapper(project, new ImmutablePair<>(ext, projectUri), serverDefinition);
 
             LOG.info("Adding file " + fileName);
             wrapper.connect(editor);
         });
     }
 
-    private static synchronized LanguageServerWrapper updateLanguageWrapperContainers(Project project, final Pair<String, String> key, LanguageServerDefinition serverDefinition) {
+    /**
+     * Returns the newly created LanguageServerWrapper if necessary; otherwise it returns null
+     */
+    private static synchronized LanguageServerWrapper addLanguageServerWrapper(Project project, final Pair<String, String> key, LanguageServerDefinition serverDefinition) {
         String projectUri = FileUtils.projectToUri(project);
         LanguageServerWrapper wrapper = extToLanguageWrapper.get(key);
         String ext = key.getLeft();
@@ -269,12 +275,11 @@ public class IntellijLanguageClient implements ApplicationComponent, Disposable 
             Set<LanguageServerWrapper> wrappers = projectToLanguageWrappers
                     .computeIfAbsent(projectUri, k -> new HashSet<>());
             wrappers.add(wrapper);
-
+            return wrapper;
         } else {
             LOG.info("Wrapper already existing for " + ext + " , " + projectUri);
         }
-
-        return wrapper;
+        return null;
     }
 
     /**

--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -250,7 +250,7 @@ public class IntellijLanguageClient implements ApplicationComponent, Disposable 
         });
     }
 
-    static synchronized LanguageServerWrapper updateLanguageWrapperContainers(Project project, final Pair<String, String> key, LanguageServerDefinition serverDefinition) {
+    private static synchronized LanguageServerWrapper updateLanguageWrapperContainers(Project project, final Pair<String, String> key, LanguageServerDefinition serverDefinition) {
         String projectUri = FileUtils.projectToUri(project);
         LanguageServerWrapper wrapper = extToLanguageWrapper.get(key);
         String ext = key.getLeft();

--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -16,6 +16,8 @@
 package org.wso2.lsp4intellij;
 
 import com.intellij.AppTopics;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationType;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ApplicationComponent;
@@ -50,6 +52,7 @@ import java.io.File;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.pool;
 import static org.wso2.lsp4intellij.utils.FileUtils.reloadAllEditors;
@@ -85,6 +88,21 @@ public class IntellijLanguageClient implements ApplicationComponent, Disposable 
             LOG.info("Intellij Language Client initialized successfully");
         } catch (Exception e) {
             LOG.warn("Fatal error occurred when initializing Intellij language client.", e);
+        }
+    }
+
+    /**
+     * Use it to initialize the server connection for the given project (useful if no editor is launched)
+     */
+    public void initProjectConnections(@NotNull Project project) {
+        // TODO: improve: work on entrySet directly
+        String projectStr = FileUtils.projectToUri(project);
+        final List<Pair<String, String>> projectsServerDefinitionKeys = extToServerDefinition.keySet().stream().filter((p) -> p.getRight().equals(projectStr)).collect(Collectors.toList());
+
+        for (Pair<String, String> key : projectsServerDefinitionKeys) {
+            LanguageServerDefinition serverDefinition = extToServerDefinition.get(key);
+            LanguageServerWrapper wrapper = updateLanguageWrapperContainers(project, key, serverDefinition);
+            wrapper.start();
         }
     }
 
@@ -230,29 +248,39 @@ public class IntellijLanguageClient implements ApplicationComponent, Disposable 
                 LOG.warn("Could not find a server definition for " + ext);
                 return;
             }
-            LanguageServerWrapper wrapper = extToLanguageWrapper.get(new MutablePair<>(ext, projectUri));
-            if (wrapper == null) {
-                LOG.info("Instantiating wrapper for " + ext + " : " + projectUri);
-                if (extToExtManager.get(ext) != null) {
-                    wrapper = new LanguageServerWrapper(serverDefinition, project, extToExtManager.get(ext));
-                } else {
-                    wrapper = new LanguageServerWrapper(serverDefinition, project);
-                }
-                String[] exts = serverDefinition.ext.split(LanguageServerDefinition.SPLIT_CHAR);
-                for (String ex : exts) {
-                    extToLanguageWrapper.put(new ImmutablePair<>(ex, projectUri), wrapper);
-                }
+            // Update project mapping for language servers.
+            LanguageServerWrapper wrapper = updateLanguageWrapperContainers(project, new ImmutablePair<>(ext, projectUri), serverDefinition);
 
-                // Update project mapping for language servers.
-                Set<LanguageServerWrapper> wrappers = projectToLanguageWrappers
-                        .computeIfAbsent(projectUri, k -> new HashSet<>());
-                wrappers.add(wrapper);
-            } else {
-                LOG.info("Wrapper already existing for " + ext + " , " + projectUri);
-            }
             LOG.info("Adding file " + fileName);
             wrapper.connect(editor);
         });
+    }
+
+    public synchronized LanguageServerWrapper updateLanguageWrapperContainers(Project project, final Pair<String, String> key, LanguageServerDefinition serverDefinition) {
+        String projectUri = FileUtils.projectToUri(project);
+        LanguageServerWrapper wrapper = extToLanguageWrapper.get(key);
+        String ext = key.getLeft();
+        if (wrapper == null) {
+            LOG.info("Instantiating wrapper for " + ext + " : " + projectUri);
+            if (extToExtManager.get(ext) != null) {
+                wrapper = new LanguageServerWrapper(serverDefinition, project, extToExtManager.get(ext));
+            } else {
+                wrapper = new LanguageServerWrapper(serverDefinition, project);
+            }
+            String[] exts = serverDefinition.ext.split(LanguageServerDefinition.SPLIT_CHAR);
+            for (String ex : exts) {
+                extToLanguageWrapper.put(new ImmutablePair<>(ex, projectUri), wrapper);
+            }
+
+            Set<LanguageServerWrapper> wrappers = projectToLanguageWrappers
+                    .computeIfAbsent(projectUri, k -> new HashSet<>());
+            wrappers.add(wrapper);
+
+        } else {
+            LOG.info("Wrapper already existing for " + ext + " , " + projectUri);
+        }
+
+        return wrapper;
     }
 
     /**

--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -16,8 +16,6 @@
 package org.wso2.lsp4intellij;
 
 import com.intellij.AppTopics;
-import com.intellij.notification.Notification;
-import com.intellij.notification.NotificationType;
 import com.intellij.openapi.Disposable;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ApplicationComponent;
@@ -256,7 +254,7 @@ public class IntellijLanguageClient implements ApplicationComponent, Disposable 
         });
     }
 
-    public synchronized LanguageServerWrapper updateLanguageWrapperContainers(Project project, final Pair<String, String> key, LanguageServerDefinition serverDefinition) {
+    static synchronized LanguageServerWrapper updateLanguageWrapperContainers(Project project, final Pair<String, String> key, LanguageServerDefinition serverDefinition) {
         String projectUri = FileUtils.projectToUri(project);
         LanguageServerWrapper wrapper = extToLanguageWrapper.get(key);
         String ext = key.getLeft();

--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -50,7 +50,6 @@ import java.io.File;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.pool;
 import static org.wso2.lsp4intellij.utils.FileUtils.reloadAllEditors;
@@ -93,15 +92,12 @@ public class IntellijLanguageClient implements ApplicationComponent, Disposable 
      * Use it to initialize the server connection for the given project (useful if no editor is launched)
      */
     public void initProjectConnections(@NotNull Project project) {
-        // TODO: improve: work on entrySet directly
         String projectStr = FileUtils.projectToUri(project);
-        final List<Pair<String, String>> projectsServerDefinitionKeys = extToServerDefinition.keySet().stream().filter((p) -> p.getRight().equals(projectStr)).collect(Collectors.toList());
+        // find serverdefinition keys for this project and try to start a wrapper
+        extToServerDefinition.entrySet().stream().filter((e) -> e.getKey().getRight().equals(projectStr)).forEach(entry -> {
+            updateLanguageWrapperContainers(project, entry.getKey(), entry.getValue()).start();
+        });
 
-        for (Pair<String, String> key : projectsServerDefinitionKeys) {
-            LanguageServerDefinition serverDefinition = extToServerDefinition.get(key);
-            LanguageServerWrapper wrapper = updateLanguageWrapperContainers(project, key, serverDefinition);
-            wrapper.start();
-        }
     }
 
     /**

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -438,7 +438,7 @@ public class LanguageServerWrapper {
     /**
      * Starts the LanguageServer
      */
-    private void start() {
+    public void start() {
         if (status == STOPPED && !alreadyShownCrash && !alreadyShownTimeout) {
             setStatus(STARTING);
             try {


### PR DESCRIPTION
## Purpose
closes #203. Allows to startup the projects server connections (previously added via `addServerDefinition(..)` ) without the need to open an Editor.

## Approach
added  `initProjectConnections(@NotNull Project project)` to the `IntelliJLanguageClient`.
The method iterates over the datastructure to find the serverdefinition keys for this project and try to start a wrapper.
For codereuse the `LanguageServerWrapper` initialization inside of `connect(Editor)` was refactored into another method.  