### PR TITLE
Bump lsp4j version to v0.10.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ intellij {
 }
 
 dependencies {
-    compile group: 'org.eclipse.lsp4j', name: 'org.eclipse.lsp4j', version: '0.9.0'
+    compile group: 'org.eclipse.lsp4j', name: 'org.eclipse.lsp4j', version: '0.10.0'
     compile group: 'com.vladsch.flexmark', name: 'flexmark', version: '0.34.58'
     compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
     testCompile group: 'junit', name: 'junit', version: '4.11'


### PR DESCRIPTION
Fixes #207

See https://github.com/eclipse/lsp4j/releases/tag/v0.10.0 for the lsp4j changelog. All breaking changes in this release are related to DAP, so nothing other than bumping the library version should need to be done.