### PR TITLE
Add tabsize to FormattingOptions

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -687,6 +687,7 @@ public class EditorEventManager {
             params.setTextDocument(identifier);
             FormattingOptions options = new FormattingOptions();
             options.setTabSize(DocumentUtils.getTabSize(editor));
+            options.setInsertSpaces(DocumentUtils.shouldUseSpaces(editor));
             params.setOptions(options);
 
             CompletableFuture<List<? extends TextEdit>> request = requestManager.formatting(params);
@@ -720,6 +721,7 @@ public class EditorEventManager {
             // Todo - Make Formatting Options configurable
             FormattingOptions options = new FormattingOptions();
             options.setTabSize(DocumentUtils.getTabSize(editor));
+            options.setInsertSpaces(DocumentUtils.shouldUseSpaces(editor));
             params.setOptions(options);
 
             CompletableFuture<List<? extends TextEdit>> request = requestManager.rangeFormatting(params);

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -686,6 +686,7 @@ public class EditorEventManager {
             DocumentFormattingParams params = new DocumentFormattingParams();
             params.setTextDocument(identifier);
             FormattingOptions options = new FormattingOptions();
+            options.setTabSize(DocumentUtils.getTabSize(editor));
             params.setOptions(options);
 
             CompletableFuture<List<? extends TextEdit>> request = requestManager.formatting(params);
@@ -718,6 +719,7 @@ public class EditorEventManager {
             params.setRange(new Range(startingPos, endPos));
             // Todo - Make Formatting Options configurable
             FormattingOptions options = new FormattingOptions();
+            options.setTabSize(DocumentUtils.getTabSize(editor));
             params.setOptions(options);
 
             CompletableFuture<List<? extends TextEdit>> request = requestManager.rangeFormatting(params);

--- a/src/main/java/org/wso2/lsp4intellij/utils/DocumentUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/DocumentUtils.java
@@ -160,4 +160,8 @@ public class DocumentUtils {
             }
         });
     }
+
+    public static int getTabSize(Editor editor){
+        return computableReadAction(() -> editor.getSettings().getTabSize(editor.getProject()));
+    }
 }

--- a/src/main/java/org/wso2/lsp4intellij/utils/DocumentUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/DocumentUtils.java
@@ -164,4 +164,10 @@ public class DocumentUtils {
     public static int getTabSize(Editor editor){
         return computableReadAction(() -> editor.getSettings().getTabSize(editor.getProject()));
     }
+
+    public static boolean shouldUseSpaces(Editor editor){
+        return computableReadAction(() -> !editor.getSettings().isUseTabCharacter(editor.getProject()));
+    }
+
+
 }


### PR DESCRIPTION
Fixes #208 

Use the projects tabsize and sets the corresponding property on the FormattingOptions object before making a reformat request.