### PR TITLE
fixes removal of listeners in case another editor w/same uri is closed

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/listeners/LSPEditorListener.java
+++ b/src/main/java/org/wso2/lsp4intellij/listeners/LSPEditorListener.java
@@ -15,18 +15,24 @@
  */
 package org.wso2.lsp4intellij.listeners;
 
-import com.intellij.openapi.editor.event.EditorFactoryEvent;
-import com.intellij.openapi.editor.event.EditorFactoryListener;
-import org.jetbrains.annotations.NotNull;
-import org.wso2.lsp4intellij.IntellijLanguageClient;
+        import com.intellij.openapi.components.ServiceManager;
+        import com.intellij.openapi.editor.EditorKind;
+        import com.intellij.openapi.editor.event.EditorFactoryEvent;
+        import com.intellij.openapi.editor.event.EditorFactoryListener;
+        import org.jetbrains.annotations.NotNull;
+        import org.wso2.lsp4intellij.IntellijLanguageClient;
 
 public class LSPEditorListener implements EditorFactoryListener {
 
     public void editorReleased(@NotNull EditorFactoryEvent editorFactoryEvent) {
-        IntellijLanguageClient.editorClosed(editorFactoryEvent.getEditor());
+        if(editorFactoryEvent.getEditor().getEditorKind() == EditorKind.MAIN_EDITOR){
+            IntellijLanguageClient.editorClosed(editorFactoryEvent.getEditor());
+        }
     }
 
     public void editorCreated(@NotNull EditorFactoryEvent editorFactoryEvent) {
-        IntellijLanguageClient.editorOpened(editorFactoryEvent.getEditor());
+        if(editorFactoryEvent.getEditor().getEditorKind() == EditorKind.MAIN_EDITOR) {
+            IntellijLanguageClient.editorOpened(editorFactoryEvent.getEditor());
+        }
     }
 }


### PR DESCRIPTION
happens e.g. in preview editors like in references or commit dialog;

limits usage of lsp features to editors which are shown in tabs -> EditorKind.MAIN_EDITOR


closes #229