### PR TITLE
fixes multiple problems with split / preview editors

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -283,7 +283,7 @@ public class IntellijLanguageClient implements ApplicationComponent, Disposable 
      * @param editor the editor.
      */
     public static void editorClosed(Editor editor) {
-        VirtualFile file = FileDocumentManager.getInstance().getFile(editor.getDocument());
+        VirtualFile file = FileUtils.virtualFileFromEditor(editor);
         if (!FileUtils.isFileSupported(file)) {
             LOG.debug("Handling close on a editor which host a LightVirtual/Null file");
             return;

--- a/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
@@ -108,8 +108,8 @@ public class DefaultLanguageClient implements LanguageClient {
     public void publishDiagnostics(PublishDiagnosticsParams publishDiagnosticsParams) {
         String uri = FileUtils.sanitizeURI(publishDiagnosticsParams.getUri());
         List<Diagnostic> diagnostics = publishDiagnosticsParams.getDiagnostics();
-        EditorEventManager manager = EditorEventManagerBase.forUri(uri);
-        if (manager != null) {
+        Set<EditorEventManager> managers = EditorEventManagerBase.managersForUri(uri);
+        for (EditorEventManager manager: managers) {
             manager.diagnostics(diagnostics);
         }
     }

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/ServerStatus.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/ServerStatus.java
@@ -19,5 +19,5 @@ package org.wso2.lsp4intellij.client.languageserver;
  * An enum representing a server status
  */
 public enum ServerStatus {
-    STOPPED, STARTING, STARTED, INITIALIZED
+    STOPPED, STARTING, STARTED, INITIALIZED, STOPPING
 }

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -459,7 +459,7 @@ public class LanguageServerWrapper {
             ApplicationUtils.restartPool();
             // sadly this whole editor closing stuff runs asynchronously, so we cannot be sure the state is really clean here...
             // therefore clear the mapping from here as it should be empty by now.
-            DocumentEventManager.uriToDocumentEventManager.clear();
+            DocumentEventManager.clearState();
             uriToEditorManagers.clear();
             urisUnderLspControl.clear();
             launcherFuture = null;

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -416,6 +416,9 @@ public class LanguageServerWrapper {
      * Only if the exit flag is true, particular server instance will exit.
      */
     public void stop(boolean exit) {
+        if(this.status == STOPPED){
+            return;
+        }
         try {
             if (initializeFuture != null) {
                 initializeFuture.cancel(true);
@@ -442,7 +445,7 @@ public class LanguageServerWrapper {
             if (serverDefinition != null) {
                 serverDefinition.stop(projectRootPath);
             }
-            for (Editor ed : connectedEditors) {
+            for (Editor ed : new HashSet<>(connectedEditors)) {
                 disconnect(ed);
             }
             languageServer = null;

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -20,16 +20,15 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.fileEditor.FileEditor;
 import com.intellij.openapi.fileEditor.FileEditorManager;
-import com.intellij.openapi.fileEditor.TextEditor;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.MessageType;
 import com.intellij.openapi.ui.Messages;
+import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
 import com.intellij.remoteServer.util.CloudNotifier;
 import com.intellij.util.PlatformIcons;
 import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.CodeActionCapabilities;
@@ -78,6 +77,7 @@ import org.wso2.lsp4intellij.client.languageserver.requestmanager.DefaultRequest
 import org.wso2.lsp4intellij.client.languageserver.requestmanager.RequestManager;
 import org.wso2.lsp4intellij.client.languageserver.serverdefinition.LanguageServerDefinition;
 import org.wso2.lsp4intellij.editor.EditorEventManager;
+import org.wso2.lsp4intellij.editor.EditorEventManagerBase;
 import org.wso2.lsp4intellij.extensions.LSPExtensionManager;
 import org.wso2.lsp4intellij.listeners.DocumentListenerImpl;
 import org.wso2.lsp4intellij.listeners.EditorMouseListenerImpl;
@@ -93,10 +93,10 @@ import java.io.OutputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
@@ -131,7 +131,9 @@ public class LanguageServerWrapper {
     private final Project project;
     private final HashSet<Editor> toConnect = new HashSet<>();
     private final String projectRootPath;
-    private final Map<String, EditorEventManager> connectedEditors = new ConcurrentHashMap<>();
+    private final HashSet<String> urisUnderLspControl = new HashSet<>();
+    private final HashSet<Editor> connectedEditors = new HashSet<>();
+    private final Map<String, Set<EditorEventManager>> uriToEditorManagers = new HashMap<>();
     private final LSPServerStatusWidget statusWidget;
     private LanguageServer languageServer;
     private LanguageClient client;
@@ -164,17 +166,13 @@ public class LanguageServerWrapper {
         this.extManager = extManager;
     }
 
-    public Map<String, EditorEventManager> getConnectedEditors() {
-        return connectedEditors;
-    }
-
     /**
      * @param uri     A file uri
      * @param project The related project
      * @return The wrapper for the given uri, or None
      */
     public static LanguageServerWrapper forUri(String uri, Project project) {
-        return uriToLanguageServerWrapper.get(new MutablePair<>(uri, FileUtils.projectToUri(project)));
+        return uriToLanguageServerWrapper.get(new ImmutablePair<>(uri, FileUtils.projectToUri(project)));
     }
 
     /**
@@ -182,7 +180,7 @@ public class LanguageServerWrapper {
      * @return The wrapper for the given editor, or None
      */
     public static LanguageServerWrapper forEditor(Editor editor) {
-        return uriToLanguageServerWrapper.get(new MutablePair<>(editorToURIString(editor), editorToProjectFolderUri(editor)));
+        return uriToLanguageServerWrapper.get(new ImmutablePair<>(editorToURIString(editor), editorToProjectFolderUri(editor)));
     }
 
     public LanguageServerDefinition getServerDefinition() {
@@ -198,10 +196,10 @@ public class LanguageServerWrapper {
      */
     public boolean isWillSaveWaitUntil() {
         return Optional.ofNullable(getServerCapabilities())
-          .map(ServerCapabilities::getTextDocumentSync)
-          .map(Either::getRight)
-          .map(TextDocumentSyncOptions::getWillSaveWaitUntil)
-          .orElse(false);
+                .map(ServerCapabilities::getTextDocumentSync)
+                .map(Either::getRight)
+                .map(TextDocumentSyncOptions::getWillSaveWaitUntil)
+                .orElse(false);
     }
 
     /**
@@ -256,11 +254,35 @@ public class LanguageServerWrapper {
     /**
      * Returns the EditorEventManager for a given uri
      *
+     * WARNING: actually a file can be present in multiple editors, this function just gives you one editor. use {@link #getEditorManagersFor(String)} instead
+     * only use for document level events such as open, close, ...
+     *
      * @param uri the URI as a string
      * @return the EditorEventManager (or null)
      */
     public EditorEventManager getEditorManagerFor(String uri) {
-        return connectedEditors.get(uri);
+        FileEditor selectedEditor = FileEditorManager.getInstance(project).getSelectedEditor();
+
+        if (selectedEditor == null) {
+            return null;
+        }
+        VirtualFile currentOpenFile = selectedEditor.getFile();
+        VirtualFile requestedFile = FileUtils.virtualFileFromURI(uri);
+        if (currentOpenFile == null || requestedFile == null) {
+            return null;
+        }
+        if (requestedFile.equals(currentOpenFile)) {
+            return EditorEventManagerBase.forEditor((Editor) FileEditorManager.getInstance(project).getSelectedEditor());
+        }
+        if(uriToEditorManagers.containsKey(uri) && !uriToEditorManagers.get(uri).isEmpty()){
+            return (EditorEventManager) uriToEditorManagers.get(uri).toArray()[0];
+        }
+
+        return null;
+    }
+
+    public Set<EditorEventManager> getEditorManagersFor(String uri) {
+        return uriToEditorManagers.get(uri);
     }
 
     /**
@@ -294,10 +316,13 @@ public class LanguageServerWrapper {
         }
 
         String uri = editorToURIString(editor);
-        uriToLanguageServerWrapper.put(new MutablePair<>(uri, editorToProjectFolderUri(editor)), this);
-        if (connectedEditors.containsKey(uri)) {
+        if (connectedEditors.contains(editor)) {
             return;
         }
+        ImmutablePair<String,String> key = new ImmutablePair<>(uri, editorToProjectFolderUri(editor));
+
+        uriToLanguageServerWrapper.put(key, this);
+
         start();
         if (initializeFuture != null) {
             ServerCapabilities capabilities = getServerCapabilities();
@@ -307,7 +332,7 @@ public class LanguageServerWrapper {
             }
 
             initializeFuture.thenRun(() -> {
-                if (connectedEditors.containsKey(uri)) {
+                if (connectedEditors.contains(editor)) {
                     return;
                 }
                 try {
@@ -342,8 +367,19 @@ public class LanguageServerWrapper {
                         mouseMotionListener.setManager(manager);
                         caretListener.setManager(manager);
                         manager.registerListeners();
-                        connectedEditors.put(uri, manager);
-                        manager.documentOpened();
+                        if(!urisUnderLspControl.contains(uri)){
+                            manager.documentEventManager.registerListeners();
+                        }
+                        urisUnderLspControl.add(uri);
+                        connectedEditors.add(editor);
+                        if (uriToEditorManagers.containsKey(uri)) {
+                            uriToEditorManagers.get(uri).add(manager);
+                        } else {
+                            Set<EditorEventManager> set = new HashSet<>();
+                            set.add(manager);
+                            uriToEditorManagers.put(uri, set);
+                            manager.documentOpened();
+                        }
                         LOG.info("Created a manager for " + uri);
                         synchronized (toConnect) {
                             toConnect.remove(editor);
@@ -405,8 +441,8 @@ public class LanguageServerWrapper {
             if (serverDefinition != null) {
                 serverDefinition.stop(projectRootPath);
             }
-            for (Map.Entry<String, EditorEventManager> ed : connectedEditors.entrySet()) {
-                disconnect(ed.getValue().editor);
+            for (Editor ed : connectedEditors) {
+                disconnect(ed);
             }
             languageServer = null;
             setStatus(STOPPED);
@@ -420,7 +456,7 @@ public class LanguageServerWrapper {
      * @return True if the given file is connected.
      */
     public boolean isConnectedTo(String location) {
-        return connectedEditors.containsKey(location);
+        return urisUnderLspControl.contains(location);
     }
 
     /**
@@ -586,7 +622,7 @@ public class LanguageServerWrapper {
 
     private void reconnect() {
         // Need to copy by value since connected editors gets cleared during 'stop()' invocation.
-        final Set<String> connected = new HashSet<>(connectedEditors.keySet());
+        final Set<String> connected = new HashSet<>(urisUnderLspControl);
         stop(true);
         for (String uri : connected) {
             connect(uri);
@@ -595,7 +631,7 @@ public class LanguageServerWrapper {
 
     public List<String> getConnectedFiles() {
         List<String> connected = new ArrayList<>();
-        connectedEditors.keySet().forEach(s -> {
+        urisUnderLspControl.forEach(s -> {
             try {
                 connected.add(new URI(sanitizeURI(s)).toString());
             } catch (URISyntaxException e) {
@@ -615,11 +651,23 @@ public class LanguageServerWrapper {
      * @param editor The editor
      */
     public void disconnect(Editor editor) {
-        EditorEventManager manager = connectedEditors.remove(editorToURIString(editor));
+        EditorEventManager manager = EditorEventManagerBase.forEditor(editor);
+        connectedEditors.remove(editor);
         if (manager != null) {
             manager.removeListeners();
-            manager.documentClosed();
-            uriToLanguageServerWrapper.remove(new ImmutablePair<>(editorToURIString(editor), editorToProjectFolderUri(editor)));
+            String uri = editorToURIString(editor);
+            Set<EditorEventManager> set = uriToEditorManagers.get(uri);
+            if (set != null) {
+                set.remove(manager);
+                if (set.isEmpty()) {
+                    manager.documentClosed();
+                    manager.documentEventManager.removeListeners();
+
+                    uriToEditorManagers.remove(uri);
+                    urisUnderLspControl.remove(uri);
+                    uriToLanguageServerWrapper.remove(new ImmutablePair<>(uri, editorToProjectFolderUri(editor)));
+                }
+            }
         }
 
         if (connectedEditors.isEmpty()) {
@@ -630,14 +678,29 @@ public class LanguageServerWrapper {
     /**
      * Disconnects an editor from the LanguageServer
      *
+     * WARNING: only use this method if you have no editor instance and you restart all connections to the language server for all open editors
+     * prefer using disconnect(editor)
+     *
      * @param uri        The file uri
      * @param projectUri The project root uri
      */
     public void disconnect(String uri, String projectUri) {
-        EditorEventManager manager = connectedEditors.remove(sanitizeURI(uri));
-        if (manager != null) {
+        uriToLanguageServerWrapper.remove(new ImmutablePair<>(sanitizeURI(uri), sanitizeURI(projectUri)));
+
+        Set<EditorEventManager> managers = uriToEditorManagers.get(uri);
+        for (EditorEventManager manager : managers) {
             manager.removeListeners();
-            manager.documentClosed();
+            manager.documentEventManager.removeListeners();
+            connectedEditors.remove(manager.editor);
+            Set<EditorEventManager> editorEventManagers = uriToEditorManagers.get(uri);
+            if (editorEventManagers != null) {
+                editorEventManagers.remove(manager);
+                if (editorEventManagers.isEmpty()) {
+                    uriToEditorManagers.remove(uri);
+                    manager.documentClosed();
+                }
+            }
+            urisUnderLspControl.remove(uri);
             uriToLanguageServerWrapper.remove(new ImmutablePair<>(sanitizeURI(uri), sanitizeURI(projectUri)));
         }
         if (connectedEditors.isEmpty()) {
@@ -652,17 +715,10 @@ public class LanguageServerWrapper {
     }
 
     private void connect(String uri) {
-        FileEditor[] fileEditors = FileEditorManager.getInstance(project)
-                .getAllEditors(Objects.requireNonNull(FileUtils.URIToVFS(uri)));
+        List<Editor> editors = FileUtils.getAllOpenedEditorsForUri(project, uri);
 
-        List<Editor> editors = new ArrayList<>();
-        for (FileEditor ed : fileEditors) {
-            if (ed instanceof TextEditor) {
-                editors.add(((TextEditor) ed).getEditor());
-            }
-        }
-        if (!editors.isEmpty()) {
-            connect(editors.get(0));
+        for (Editor editor : editors) {
+            connect(editor);
         }
     }
 

--- a/src/main/java/org/wso2/lsp4intellij/contributors/LSPCompletionContributor.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/LSPCompletionContributor.java
@@ -23,6 +23,7 @@ import com.intellij.codeInsight.completion.CompletionType;
 import com.intellij.openapi.application.ex.ApplicationUtil;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.progress.ProgressIndicatorProvider;
 import com.intellij.openapi.vfs.VirtualFile;
@@ -84,9 +85,9 @@ class LSPCompletionContributor extends CompletionContributor {
             return false;
         }
 
-        String uri = FileUtils.VFSToURI(file);
-        EditorEventManager manager = EditorEventManagerBase.forUri(uri);
-        if (manager == null) {
+        Editor editor = FileEditorManager.getInstance(position.getProject()).getSelectedTextEditor();
+        EditorEventManager manager = EditorEventManagerBase.forEditor(editor);
+        if (editor == null || manager == null) {
             return false;
         }
         for (String triggerChar : manager.completionTriggers) {

--- a/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
@@ -27,6 +27,8 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.wso2.lsp4intellij.IntellijLanguageClient;
+import org.wso2.lsp4intellij.client.languageserver.ServerStatus;
+import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
 import org.wso2.lsp4intellij.editor.EditorEventManager;
 import org.wso2.lsp4intellij.editor.EditorEventManagerBase;
 import org.wso2.lsp4intellij.utils.DocumentUtils;
@@ -54,7 +56,7 @@ public class LSPAnnotator extends ExternalAnnotator<Object, Object> {
             }
             EditorEventManager eventManager = EditorEventManagerBase.forEditor(editor);
 
-            if(eventManager == null){
+            if (eventManager == null) {
                 return null;
             }
 
@@ -76,6 +78,10 @@ public class LSPAnnotator extends ExternalAnnotator<Object, Object> {
 
     @Override
     public void apply(@NotNull PsiFile file, Object annotationResult, @NotNull AnnotationHolder holder) {
+
+        if (LanguageServerWrapper.forVirtualFile(file.getVirtualFile(), file.getProject()).getStatus() != ServerStatus.INITIALIZED) {
+            return;
+        }
 
         VirtualFile virtualFile = file.getVirtualFile();
         if (FileUtils.isFileSupported(virtualFile) && IntellijLanguageClient.isExtensionSupported(virtualFile)) {

--- a/src/main/java/org/wso2/lsp4intellij/contributors/fixes/LSPCodeActionFix.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/fixes/LSPCodeActionFix.java
@@ -62,7 +62,7 @@ public class LSPCodeActionFix implements IntentionAction {
         if (codeAction.getEdit() != null) {
             WorkspaceEditHandler.applyEdit(codeAction.getEdit(), codeAction.getTitle());
         }
-        EditorEventManager manager = EditorEventManagerBase.forUri(uri);
+        EditorEventManager manager = EditorEventManagerBase.forEditor(editor);
         if (manager != null) {
             manager.executeCommands(Collections.singletonList(codeAction.getCommand()));
         }

--- a/src/main/java/org/wso2/lsp4intellij/contributors/fixes/LSPCommandFix.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/fixes/LSPCommandFix.java
@@ -58,7 +58,7 @@ public class LSPCommandFix implements IntentionAction {
 
     @Override
     public void invoke(@NotNull Project project, Editor editor, PsiFile psiFile) {
-        EditorEventManager manager = EditorEventManagerBase.forUri(uri);
+        EditorEventManager manager = EditorEventManagerBase.forEditor(editor);
         if (manager != null) {
             manager.executeCommands(singletonList(command));
         }

--- a/src/main/java/org/wso2/lsp4intellij/contributors/icon/LSPDefaultIconProvider.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/icon/LSPDefaultIconProvider.java
@@ -30,9 +30,9 @@ import javax.swing.Icon;
 
 public class LSPDefaultIconProvider extends LSPIconProvider {
 
-    private static Icon STARTED = IconLoader.getIcon("/images/started.png");
-    private static Icon STARTING = IconLoader.getIcon("/images/starting.png");
-    private static Icon STOPPED = IconLoader.getIcon("/images/stopped.png");
+    private static Icon GREEN = IconLoader.getIcon("/images/started.png");
+    private static Icon YELLOW = IconLoader.getIcon("/images/starting.png");
+    private static Icon RED = IconLoader.getIcon("/images/stopped.png");
 
     public Icon getCompletionIcon(CompletionItemKind kind) {
 
@@ -103,10 +103,11 @@ public class LSPDefaultIconProvider extends LSPIconProvider {
 
     public Map<ServerStatus, Icon> getStatusIcons() {
         Map<ServerStatus, Icon> statusIconMap = new HashMap<>();
-        statusIconMap.put(ServerStatus.STOPPED, STOPPED);
-        statusIconMap.put(ServerStatus.STARTING, STARTING);
-        statusIconMap.put(ServerStatus.STARTED, STARTING);
-        statusIconMap.put(ServerStatus.INITIALIZED, STARTED);
+        statusIconMap.put(ServerStatus.STOPPED, RED);
+        statusIconMap.put(ServerStatus.STARTING, YELLOW);
+        statusIconMap.put(ServerStatus.STARTED, YELLOW);
+        statusIconMap.put(ServerStatus.INITIALIZED, GREEN);
+        statusIconMap.put(ServerStatus.STOPPING, YELLOW);
         return statusIconMap;
     }
 

--- a/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.wso2.lsp4intellij.editor;
 
 import com.intellij.openapi.diagnostic.Logger;

--- a/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
@@ -1,0 +1,140 @@
+package org.wso2.lsp4intellij.editor;
+
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Document;
+import com.intellij.openapi.editor.event.DocumentEvent;
+import com.intellij.openapi.editor.event.DocumentListener;
+import com.intellij.openapi.fileEditor.FileDocumentManager;
+import com.intellij.openapi.util.text.StringUtil;
+import org.eclipse.lsp4j.DidChangeTextDocumentParams;
+import org.eclipse.lsp4j.DidCloseTextDocumentParams;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextDocumentItem;
+import org.eclipse.lsp4j.TextDocumentSyncKind;
+import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
+import org.wso2.lsp4intellij.client.languageserver.requestmanager.RequestManager;
+import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
+import org.wso2.lsp4intellij.utils.ApplicationUtils;
+import org.wso2.lsp4intellij.utils.DocumentUtils;
+import org.wso2.lsp4intellij.utils.FileUtils;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+public class DocumentEventManager {
+    private final Document document;
+    private final DocumentListener documentListener;
+    private final TextDocumentSyncKind syncKind;
+    private final RequestManager requestManager;
+    private final LanguageServerWrapper wrapper;
+    private final TextDocumentIdentifier identifier;
+    private int version = -1;
+    protected Logger LOG = Logger.getInstance(EditorEventManager.class);
+    private static final Map<String, DocumentEventManager> uriToDocumentEventManager = new HashMap<>();
+
+    private final Set<Document> openDocuments = new HashSet<>();
+
+    DocumentEventManager(Document document, DocumentListener documentListener, TextDocumentSyncKind syncKind, RequestManager requestManager, LanguageServerWrapper wrapper){
+        this.document = document;
+        this.documentListener = documentListener;
+        this.syncKind = syncKind;
+        this.requestManager = requestManager;
+        this.wrapper = wrapper;
+        this.identifier = new TextDocumentIdentifier(FileUtils.documentToUri(document));
+    }
+
+    public static DocumentEventManager getOrCreateDocumentManager(Document document, DocumentListener listener, TextDocumentSyncKind syncKind, RequestManager requestManager, LanguageServerWrapper wrapper){
+        DocumentEventManager manager = uriToDocumentEventManager.get(FileUtils.documentToUri(document));
+        if(manager != null){
+            return manager;
+        }
+
+        manager = new DocumentEventManager(document, listener, syncKind, requestManager, wrapper);
+
+        uriToDocumentEventManager.put(FileUtils.documentToUri(document), manager);
+        return manager;
+    }
+
+    public void removeListeners() {
+        document.removeDocumentListener(documentListener);
+    }
+
+    public void registerListeners() {
+        document.addDocumentListener(documentListener);
+    }
+
+    public int getDocumentVersion(){
+        return this.version;
+    }
+
+    public void documentChanged(DocumentEvent event) {
+
+        DidChangeTextDocumentParams changesParams = new DidChangeTextDocumentParams(new VersionedTextDocumentIdentifier(),
+                Collections.singletonList(new TextDocumentContentChangeEvent()));
+        changesParams.getTextDocument().setUri(identifier.getUri());
+
+        changesParams.getTextDocument().setVersion(version++);
+
+        if (syncKind == TextDocumentSyncKind.Incremental) {
+            TextDocumentContentChangeEvent changeEvent = changesParams.getContentChanges().get(0);
+            CharSequence newText = event.getNewFragment();
+            int offset = event.getOffset();
+            int newTextLength = event.getNewLength();
+            Position lspPosition = DocumentUtils.offsetToLSPPos(document, offset);
+            int startLine = lspPosition.getLine();
+            int startColumn = lspPosition.getCharacter();
+            CharSequence oldText = event.getOldFragment();
+
+            //if text was deleted/replaced, calculate the end position of inserted/deleted text
+            int endLine, endColumn;
+            if (oldText.length() > 0) {
+                endLine = startLine + StringUtil.countNewLines(oldText);
+                String content = oldText.toString();
+                String[] oldLines = content.split("\n");
+                int oldTextLength = oldLines.length == 0 ? 0 : oldLines[oldLines.length - 1].length();
+                endColumn = content.endsWith("\n") ? 0 : oldLines.length == 1 ? startColumn + oldTextLength : oldTextLength;
+            } else { //if insert or no text change, the end position is the same
+                endLine = startLine;
+                endColumn = startColumn;
+            }
+            Range range = new Range(new Position(startLine, startColumn), new Position(endLine, endColumn));
+            changeEvent.setRange(range);
+            changeEvent.setRangeLength(newTextLength);
+            changeEvent.setText(newText.toString());
+        } else if (syncKind == TextDocumentSyncKind.Full) {
+            changesParams.getContentChanges().get(0).setText(document.getText());
+        }
+        ApplicationUtils.pool(() -> requestManager.didChange(changesParams));
+    }
+
+    public void documentOpened() {
+        if (openDocuments.contains(document)) {
+            LOG.warn("trying to send open notification for document which was already opened!");
+        } else {
+            openDocuments.add(document);
+            final String extension = FileDocumentManager.getInstance().getFile(document).getExtension();
+            requestManager.didOpen(new DidOpenTextDocumentParams(new TextDocumentItem(identifier.getUri(),
+                    wrapper.serverDefinition.languageIdFor(extension),
+                    version++,
+                    document.getText())));
+        }
+    }
+
+    public void documentClosed() {
+        if(!openDocuments.contains(document)) {
+            LOG.warn("trying to close document which is not open");
+        }else if(EditorEventManagerBase.managersForUri(FileUtils.documentToUri(document)).size() > 1){
+            LOG.warn("trying to close document which is still open in another editor!");
+        }else{
+            openDocuments.remove(document);
+            requestManager.didClose(new DidCloseTextDocumentParams(identifier));
+        }
+    }
+}

--- a/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
@@ -52,7 +52,7 @@ public class DocumentEventManager {
     private final TextDocumentIdentifier identifier;
     private int version = -1;
     protected Logger LOG = Logger.getInstance(EditorEventManager.class);
-    public static final Map<String, DocumentEventManager> uriToDocumentEventManager = new HashMap<>();
+    private static final Map<String, DocumentEventManager> uriToDocumentEventManager = new HashMap<>();
 
     private final Set<Document> openDocuments = new HashSet<>();
 
@@ -62,6 +62,10 @@ public class DocumentEventManager {
         this.syncKind = syncKind;
         this.wrapper = wrapper;
         this.identifier = new TextDocumentIdentifier(FileUtils.documentToUri(document));
+    }
+
+    public static void clearState() {
+        uriToDocumentEventManager.clear();
     }
 
     public static DocumentEventManager getOrCreateDocumentManager(Document document, DocumentListener listener, TextDocumentSyncKind syncKind, LanguageServerWrapper wrapper) {

--- a/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
@@ -51,11 +51,11 @@ public class DocumentEventManager {
     private final TextDocumentIdentifier identifier;
     private int version = -1;
     protected Logger LOG = Logger.getInstance(EditorEventManager.class);
-    private static final Map<String, DocumentEventManager> uriToDocumentEventManager = new HashMap<>();
+    public static final Map<String, DocumentEventManager> uriToDocumentEventManager = new HashMap<>();
 
     private final Set<Document> openDocuments = new HashSet<>();
 
-    DocumentEventManager(Document document, DocumentListener documentListener, TextDocumentSyncKind syncKind, LanguageServerWrapper wrapper){
+    DocumentEventManager(Document document, DocumentListener documentListener, TextDocumentSyncKind syncKind, LanguageServerWrapper wrapper) {
         this.document = document;
         this.documentListener = documentListener;
         this.syncKind = syncKind;
@@ -63,9 +63,9 @@ public class DocumentEventManager {
         this.identifier = new TextDocumentIdentifier(FileUtils.documentToUri(document));
     }
 
-    public static DocumentEventManager getOrCreateDocumentManager(Document document, DocumentListener listener, TextDocumentSyncKind syncKind, LanguageServerWrapper wrapper){
+    public static DocumentEventManager getOrCreateDocumentManager(Document document, DocumentListener listener, TextDocumentSyncKind syncKind, LanguageServerWrapper wrapper) {
         DocumentEventManager manager = uriToDocumentEventManager.get(FileUtils.documentToUri(document));
-        if(manager != null){
+        if (manager != null) {
             return manager;
         }
 
@@ -83,7 +83,7 @@ public class DocumentEventManager {
         document.addDocumentListener(documentListener);
     }
 
-    public int getDocumentVersion(){
+    public int getDocumentVersion() {
         return this.version;
     }
 
@@ -141,11 +141,11 @@ public class DocumentEventManager {
     }
 
     public void documentClosed() {
-        if(!openDocuments.contains(document)) {
+        if (!openDocuments.contains(document)) {
             LOG.warn("trying to close document which is not open");
-        }else if(EditorEventManagerBase.managersForUri(FileUtils.documentToUri(document)).size() > 1){
+        } else if (EditorEventManagerBase.managersForUri(FileUtils.documentToUri(document)).size() > 1) {
             LOG.warn("trying to close document which is still open in another editor!");
-        }else{
+        } else {
             openDocuments.remove(document);
             wrapper.getRequestManager().didClose(new DidCloseTextDocumentParams(identifier));
         }

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
@@ -114,17 +114,17 @@ public class EditorEventManagerBase {
                     uriToManagers.get(key).remove(manager);
                 }
             });
-            if(value.isEmpty()) {
+            if (value.isEmpty()) {
                 uriToManagers.remove(key);
             }
         });
     }
 
-    public static void registerManager(EditorEventManager manager){
+    public static void registerManager(EditorEventManager manager) {
         String uri = FileUtils.editorToURIString(manager.editor);
-        if(EditorEventManagerBase.uriToManagers.containsKey(uri)){
+        if (EditorEventManagerBase.uriToManagers.containsKey(uri)) {
             EditorEventManagerBase.uriToManagers.get(uri).add(manager);
-        }else{
+        } else {
             HashSet<EditorEventManager> set = new HashSet<>();
             set.add(manager);
             EditorEventManagerBase.uriToManagers.put(uri, set);

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
@@ -16,20 +16,22 @@
 package org.wso2.lsp4intellij.editor;
 
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.editor.ex.EditorSettingsExternalizable;
+import org.wso2.lsp4intellij.utils.FileUtils;
 import org.wso2.lsp4intellij.utils.OSUtils;
 
 import java.awt.KeyboardFocusManager;
 import java.awt.event.KeyEvent;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class EditorEventManagerBase {
 
-    public static final Map<String, EditorEventManager> uriToManager = new ConcurrentHashMap<>();
-    public static final Map<Editor, EditorEventManager> editorToManager = new ConcurrentHashMap<>();
+    private static final Map<String, Set<EditorEventManager>> uriToManagers = new ConcurrentHashMap<>();
+    private static final Map<Editor, EditorEventManager> editorToManager = new ConcurrentHashMap<>();
     private static final int CTRL_KEY_CODE = OSUtils.isMac() ? KeyEvent.VK_META : KeyEvent.VK_CONTROL;
-    protected static final long CTRL_THRESH = EditorSettingsExternalizable.getInstance().getQuickDocOnMouseOverElementDelayMillis() * 1000000;
     private volatile static boolean isKeyPressed = false;
     private volatile static boolean isCtrlDown = false;
     private volatile static CtrlRangeMarker ctrlRange;
@@ -80,26 +82,65 @@ public class EditorEventManagerBase {
         EditorEventManagerBase.isKeyPressed = isKeyPressed;
     }
 
-    /**
-     * @param uri A file uri
-     * @return The manager for the given uri, or None
-     */
-    public static EditorEventManager forUri(String uri) {
-        prune();
-        return uri == null ? null : uriToManager.get(uri);
+    public static Set<EditorEventManager> managersForUri(String uri) {
+        return uriToManagers.get(uri);
     }
 
+    /**
+     * WARNING: avoid using this function! It only gives you one editorEventManager, not all and not the one of the current editor.
+     * Only use for operations which are file-level (save, open, close,...) otherwise use {@link #managersForUri(String)} or {@link #forEditor(Editor)}
+     */
+    public static EditorEventManager forUri(String uri) {
+        if (uri == null) {
+            return null;
+        }
+        Set<EditorEventManager> managers = managersForUri(uri);
+        if (managers != null && !managers.isEmpty()) {
+            return (EditorEventManager) managers.toArray()[0];
+        }
+        return null;
+    }
+
+
     private static void prune() {
-        editorToManager.forEach((key, value) -> {
+        new HashMap<>(editorToManager).forEach((key, value) -> {
             if (!value.wrapper.isActive()) {
                 editorToManager.remove(key);
             }
         });
-        uriToManager.forEach((key, value) -> {
-            if (!value.wrapper.isActive()) {
-                editorToManager.remove(key);
+        new HashMap<>(uriToManagers).forEach((key, value) -> {
+            value.forEach((manager) -> {
+                if (!manager.wrapper.isActive()) {
+                    uriToManagers.get(key).remove(manager);
+                }
+            });
+            if(value.isEmpty()) {
+                uriToManagers.remove(key);
             }
         });
+    }
+
+    public static void registerManager(EditorEventManager manager){
+        String uri = FileUtils.editorToURIString(manager.editor);
+        if(EditorEventManagerBase.uriToManagers.containsKey(uri)){
+            EditorEventManagerBase.uriToManagers.get(uri).add(manager);
+        }else{
+            HashSet<EditorEventManager> set = new HashSet<>();
+            set.add(manager);
+            EditorEventManagerBase.uriToManagers.put(uri, set);
+        }
+        EditorEventManagerBase.editorToManager.put(manager.editor, manager);
+    }
+
+    public static void unregisterManager(EditorEventManager manager) {
+        EditorEventManagerBase.editorToManager.remove(manager.editor);
+
+        String uri = FileUtils.editorToURIString(manager.editor);
+        Set<EditorEventManager> set = EditorEventManagerBase.uriToManagers.get(uri);
+        set.remove(manager);
+        if (set.isEmpty()) {
+            EditorEventManagerBase.uriToManagers.remove(uri);
+        }
     }
 
     /**

--- a/src/main/java/org/wso2/lsp4intellij/utils/ApplicationUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/ApplicationUtils.java
@@ -20,13 +20,16 @@ import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.NoAccessDuringPsiEvents;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.Condition;
+import org.wso2.lsp4intellij.IntellijLanguageClient;
+import org.wso2.lsp4intellij.requests.Timeouts;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 
 public class ApplicationUtils {
 
-    private static final ExecutorService EXECUTOR_SERVICE;
+    private static ExecutorService EXECUTOR_SERVICE;
 
     static {
         // Single threaded executor is used to simulate a behavior of async sequencial execution.
@@ -49,6 +52,20 @@ public class ApplicationUtils {
         EXECUTOR_SERVICE.submit(runnable);
     }
 
+    static public void restartPool() {
+        EXECUTOR_SERVICE.shutdown();
+        try {
+            EXECUTOR_SERVICE.awaitTermination(IntellijLanguageClient.getTimeout(Timeouts.SHUTDOWN), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException ignored) {
+        }
+        EXECUTOR_SERVICE = Executors.newSingleThreadExecutor();
+        Runtime.getRuntime().addShutdownHook(new Thread() {
+            @Override
+            public void run() {
+                EXECUTOR_SERVICE.shutdownNow();
+            }
+        });    }
+
     static public <T> T computableReadAction(Computable<T> computable) {
         return ApplicationManager.getApplication().runReadAction(computable);
     }
@@ -63,7 +80,7 @@ public class ApplicationUtils {
 
     static public void invokeAfterPsiEvents(Runnable runnable) {
         Runnable wrapper = () -> {
-            if(NoAccessDuringPsiEvents.isInsideEventProcessing()) {
+            if (NoAccessDuringPsiEvents.isInsideEventProcessing()) {
                 invokeAfterPsiEvents(runnable);
             } else {
                 runnable.run();

--- a/src/main/java/org/wso2/lsp4intellij/utils/DocumentUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/DocumentUtils.java
@@ -90,11 +90,23 @@ public class DocumentUtils {
      * @return an LSP position
      */
     public static Position offsetToLSPPos(Editor editor, int offset) {
+        Document document = editor.getDocument();
+
+        return offsetToLSPPos(document, offset);
+    }
+
+    /**
+     * Calculates a Position given an editor and an offset
+     *
+     * @param document The editor
+     * @param offset The offset
+     * @return an LSP position
+     */
+    public static Position offsetToLSPPos(Document document, int offset) {
         return computableReadAction(() -> {
-            Document doc = editor.getDocument();
-            int line = doc.getLineNumber(offset);
-            int lineStart = doc.getLineStartOffset(line);
-            String lineTextBeforeOffset = doc.getText(TextRange.create(lineStart, offset));
+            int line = document.getLineNumber(offset);
+            int lineStart = document.getLineStartOffset(line);
+            String lineTextBeforeOffset = document.getText(TextRange.create(lineStart, offset));
             int column = lineTextBeforeOffset.length();
             return computableReadAction(() -> new Position(line, column));
         });


### PR DESCRIPTION
this is my refactoring for fixing problems with multiple open editors (split editor, preview editors...) (for example mentioned in #142 and #231)

unfortunately using a many-to-one (implicit)-mapping from editor to editorManager turned out to be the wrong abstraction, as you can have multiple editors open for the same file in intellij. i solved this by using a set of EditorEventManagers per uri and a one to one relationship from editors to EditorEventManager. This lead to problems in separating documentEvents, which are still somewhat intertwined with EditorEvents.

it's still very rough, as i tried to maintain as much as possible API-compatibility. It would be great if you can comment on how much this is needed. Also general comments are welcome.

I will test change this internally to find potential bugs and after that i hope you are interested in merging