### PR TITLE
add Deprecations

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
@@ -15,18 +15,24 @@
  */
 package org.wso2.lsp4intellij.contributors.annotator;
 
+import com.intellij.codeInspection.ProblemHighlightType;
 import com.intellij.lang.annotation.Annotation;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.ExternalAnnotator;
+import com.intellij.lang.annotation.HighlightSeverity;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import com.intellij.util.SmartList;
 import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.DiagnosticSeverity;
+import org.eclipse.lsp4j.DiagnosticTag;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 import org.wso2.lsp4intellij.IntellijLanguageClient;
+import org.wso2.lsp4intellij.contributors.fixes.LSPCodeActionFix;
 import org.wso2.lsp4intellij.editor.EditorEventManager;
 import org.wso2.lsp4intellij.editor.EditorEventManagerBase;
 import org.wso2.lsp4intellij.utils.DocumentUtils;
@@ -34,12 +40,23 @@ import org.wso2.lsp4intellij.utils.FileUtils;
 
 import java.util.ArrayList;
 import java.util.ConcurrentModificationException;
+import java.util.HashMap;
 import java.util.List;
 
 public class LSPAnnotator extends ExternalAnnotator<Object, Object> {
 
     private static final Logger LOG = Logger.getInstance(LSPAnnotator.class);
     private static final Object RESULT = new Object();
+    private static final HashMap<DiagnosticSeverity, HighlightSeverity> lspToIntellijAnnotationsMap = new HashMap<>();
+
+    static {
+        lspToIntellijAnnotationsMap.put(DiagnosticSeverity.Error, HighlightSeverity.ERROR);
+        lspToIntellijAnnotationsMap.put(DiagnosticSeverity.Warning, HighlightSeverity.WARNING);
+
+        // seem flipped, but just different semantics lsp<->intellij. Hint is rendered without any squiggle
+        lspToIntellijAnnotationsMap.put(DiagnosticSeverity.Information, HighlightSeverity.WEAK_WARNING);
+        lspToIntellijAnnotationsMap.put(DiagnosticSeverity.Hint, HighlightSeverity.INFORMATION);
+    }
 
     @Nullable
     @Override
@@ -128,18 +145,14 @@ public class LSPAnnotator extends ExternalAnnotator<Object, Object> {
         if (start >= end) {
             return null;
         }
-        final TextRange textRange = new TextRange(start, end);
-        switch (diagnostic.getSeverity()) {
-            // TODO: Use 'newAnnotation'; 'create*Annotation' methods are deprecated.
-            case Error:
-                return holder.createErrorAnnotation(textRange, diagnostic.getMessage());
-            case Warning:
-                return holder.createWarningAnnotation(textRange, diagnostic.getMessage());
-            case Information:
-                return holder.createInfoAnnotation(textRange, diagnostic.getMessage());
-            default:
-                return holder.createWeakWarningAnnotation(textRange, diagnostic.getMessage());
-        }
+        final TextRange range = new TextRange(start, end);
+
+        holder.newAnnotation(lspToIntellijAnnotationsMap.get(diagnostic.getSeverity()), diagnostic.getMessage())
+                .range(range)
+                .create();
+
+        SmartList<Annotation> asList = (SmartList<Annotation>) holder;
+        return asList.get(asList.size() - 1);
     }
 
     private void createAnnotations(AnnotationHolder holder, EditorEventManager eventManager) {
@@ -150,6 +163,9 @@ public class LSPAnnotator extends ExternalAnnotator<Object, Object> {
         diagnostics.forEach(d -> {
             Annotation annotation = createAnnotation(editor, holder, d);
             if (annotation != null) {
+                if (d.getTags().contains(DiagnosticTag.Deprecated)) {
+                    annotation.setHighlightType(ProblemHighlightType.LIKE_DEPRECATED);
+                }
                 annotations.add(annotation);
             }
         });


### PR DESCRIPTION
## Purpose
deprecations can now be rendered. This is a feature of [lsp 3.15](https://microsoft.github.io/language-server-protocol/specification#diagnostic).

also fixes #200

Note that i associated LSP-"Information" with IJ-"Weak warning" and LSP-"hint" with IJ-"information", as "hint" in vscode is rendered invisible like Information is in Intellij. This is just a different choice of semantics.