### PR TITLE
Fix versioning error and add CodeActionLiteralSupport

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -32,6 +32,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.CodeActionCapabilities;
+import org.eclipse.lsp4j.CodeActionLiteralSupportCapabilities;
 import org.eclipse.lsp4j.CompletionCapabilities;
 import org.eclipse.lsp4j.CompletionItemCapabilities;
 import org.eclipse.lsp4j.DefinitionCapabilities;
@@ -567,6 +568,7 @@ public class LanguageServerWrapper {
 
         TextDocumentClientCapabilities textDocumentClientCapabilities = new TextDocumentClientCapabilities();
         textDocumentClientCapabilities.setCodeAction(new CodeActionCapabilities());
+        textDocumentClientCapabilities.getCodeAction().setCodeActionLiteralSupport(new CodeActionLiteralSupportCapabilities());
         textDocumentClientCapabilities.setCompletion(new CompletionCapabilities(new CompletionItemCapabilities(true)));
         textDocumentClientCapabilities.setDefinition(new DefinitionCapabilities());
         textDocumentClientCapabilities.setDocumentHighlight(new DocumentHighlightCapabilities());

--- a/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
@@ -98,7 +98,8 @@ public class DocumentEventManager {
                 Collections.singletonList(new TextDocumentContentChangeEvent()));
         changesParams.getTextDocument().setUri(identifier.getUri());
 
-        changesParams.getTextDocument().setVersion(version++);
+
+        changesParams.getTextDocument().setVersion(++version);
 
         if (syncKind == TextDocumentSyncKind.Incremental) {
             TextDocumentContentChangeEvent changeEvent = changesParams.getContentChanges().get(0);
@@ -146,7 +147,7 @@ public class DocumentEventManager {
             final String extension = FileDocumentManager.getInstance().getFile(document).getExtension();
             wrapper.getRequestManager().didOpen(new DidOpenTextDocumentParams(new TextDocumentItem(identifier.getUri(),
                     wrapper.serverDefinition.languageIdFor(extension),
-                    version++,
+                    ++version,
                     document.getText())));
         }
     }


### PR DESCRIPTION
Signed-off-by: Kathryn Kodama <kathryn.s.kodama@gmail.com>

## Purpose
Fixes #249 

## Goals
- Adds `CodeActionLiteralSupport` capabilities
- increments version prior to setting text document version so that code actions are applied and do not result in `Edit version %d is older than current version %d` error
