### PR TITLE
Fix deprecations

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,89 +43,10 @@ For instructions on adding **Lsp4IntelliJ** as a dependency when using the below
   - sbt
 
 >**Info:** - The Maven publishing process is currently WIP. Thus, the possibility to add LSP4IntelliJ as a dependency will be available soon in the Maven central.
-  
-### 2. Add the language server definition
 
-1. Instantiate a concrete subclass of the
-[LanguageServerDefinition](src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/LanguageServerDefinition.java).
-
-    You can use the following concrete class:
-    
-    - **RawCommandServerDefinition(string fileExtension, string[] command)** 
-        
-        This definition can be used to start a language server using a command. 
-        
-        * You can specify multiple extensions for a server by separating them with a comma (e.g., "ts,js").
-    
-        * If you want to bind your language server definition only with a specific set of files, you can use that 
-        specific file pattern as a regex expression instead of binding with the file extension (e.g., "application*.properties").
-        
-        Examples: 
-        
-        Ballerina Language Server 
-        ```java
-        new RawCommandServerDefinition("bal", new String[]{"path/to/launcher-script.sh"});
-        ```
-        
-        BSL Language Server
-        ```java
-        String[] command = new String[]{"java","-jar","path/to/language-server.jar"};
-        new RawCommandServerDefinition("bsl,os",command);
-        ```
-       
-   - **ProcessBuilderServerDefinition(string fileExtension, string[] command)** 
-               
-       This definition is an extended form of the **RawCommandServerDefinition**, which accepts 
-       `java.lang.ProcessBuilder` instances so that the users will have more controllability over the language
-        server
-        process to be created.
-       
-       * You can specify multiple extensions for a server by separating them with a comma (e.g., "ts,js").
-   
-       * If you want to bind your language server definition only with a specific set of files, you can use that 
-       specific file pattern as a regex expression instead of binding with the file extension (e.g., "application*.properties").
-       
-       Examples: 
-       
-       Ballerina Language Server 
-       ```java
-       ProcessBuilder process = new ProcessBuilder("path/to/launcher-script.sh");
-       new ProcessBuilderServerDefinition("bal", process);
-       ```
-       
-       BSL Language Server
-       ```java
-       ProcessBuilder process = new ProcessBuilder("java","-jar","path/to/language-server.jar");
-       new ProcessBuilderServerDefinition("bsl,os", process);
-       ```
-               
-    > **Note:** All of the above implementations will use server stdin/stdout to communicate.
-
-2. To register any of the aforementioned options, implement a preloading activity in your plugin as shown 
-below.
-
->**Tip:** For other options you can use instead of implementing a preloading activity, go to [InteliJ Plugin initialization on startup](https://www.plugin-dev.com/intellij/general/plugin-initial-load/) 
-to)
-
-Example:
-
-```java
-public class BallerinaPreloadingActivity extends PreloadingActivity {
-    IntellijLanguageClient.addServerDefinition(new RawCommandServerDefinition("bal", new String[]{"path/to/launcher-script.sh"}));
-}
-```
-
-With plugin.xml containing;
-
-```xml
-<extensions defaultExtensionNs="com.intellij">
-    <preloadingActivity implementation="io.ballerina.plugins.idea.preloading.BallerinaPreloadingActivity" 
-                        id="io.ballerina.plugins.idea.preloading.BallerinaPreloadingActivity" />
-</extensions>
-```
-
-### 3. Add configurations to the plugin.xml file
-   
+### 2. Add a plugin.xml file
+<details>
+<summary>deprecated "components"-based setup</summary>
   1. Add `IntellijLanguageClient` as an application component. 
        ```xml
        <application-components>
@@ -194,9 +115,92 @@ With plugin.xml containing;
             ```
         
    > **Note:** You do not need any additional configurations for the other features.
-      
+</details>
+
+Copy the example plugin.xml [here](resources/plugin.xml.example) and place it under `src/resources/META-INF` in your plugin and adjust it to your needs.
+
+### 3. Add a preloading activity to configure LSP
+
+Implement a preloading activity in your plugin as shown below.
+
+>**Tip:** For other options you can use instead of implementing a preloading activity, go to [InteliJ Plugin initialization on startup](https://www.plugin-dev.com/intellij/general/plugin-initial-load/)
+to)
+
+Example:
+
+```java
+public class BallerinaPreloadingActivity extends PreloadingActivity {
+    public void preload(ProgressIndicator indicator) {
+        IntellijLanguageClient.addServerDefinition(new RawCommandServerDefinition("bal", new String[]{"path/to/launcher-script.sh"}));
+    }
+}
+```
+
+With plugin.xml containing;
+
+```xml
+<extensions defaultExtensionNs="com.intellij">
+    <preloadingActivity implementation="io.ballerina.plugins.idea.preloading.BallerinaPreloadingActivity" 
+                        id="io.ballerina.plugins.idea.preloading.BallerinaPreloadingActivity" />
+</extensions>
+```
+
 If you have connected to your language server successfully, you will see a green icon at the bottom-right side of your 
 IDE when opening a file that has a registered file extension as shown below.
+
+#### Alternative ways to connect to a language server
+Aside RawCommandServerDefinition there are several classes implementing [LanguageServerDefinition](src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/LanguageServerDefinition.java).
+
+You can use the following concrete class:
+
+- **RawCommandServerDefinition(string fileExtension, string[] command)**
+
+  This definition can be used to start a language server using a command.
+
+    * You can specify multiple extensions for a server by separating them with a comma (e.g., "ts,js").
+
+    * If you want to bind your language server definition only with a specific set of files, you can use that
+      specific file pattern as a regex expression instead of binding with the file extension (e.g., "application*.properties").
+
+  Examples:
+
+  Ballerina Language Server
+    ```java
+    new RawCommandServerDefinition("bal", new String[]{"path/to/launcher-script.sh"});
+    ```
+
+  BSL Language Server
+    ```java
+    String[] command = new String[]{"java","-jar","path/to/language-server.jar"};
+    new RawCommandServerDefinition("bsl,os",command);
+    ```
+
+- **ProcessBuilderServerDefinition(string fileExtension, string[] command)**
+
+  This definition is an extended form of the **RawCommandServerDefinition**, which accepts
+  `java.lang.ProcessBuilder` instances so that the users will have more controllability over the language
+  server
+  process to be created.
+
+    * You can specify multiple extensions for a server by separating them with a comma (e.g., "ts,js").
+
+    * If you want to bind your language server definition only with a specific set of files, you can use that
+      specific file pattern as a regex expression instead of binding with the file extension (e.g., "application*.properties").
+
+  Examples:
+
+  Ballerina Language Server
+    ```java
+    ProcessBuilder process = new ProcessBuilder("path/to/launcher-script.sh");
+    new ProcessBuilderServerDefinition("bal", process);
+    ```
+
+  BSL Language Server
+    ```java
+    ProcessBuilder process = new ProcessBuilder("java","-jar","path/to/language-server.jar");
+    new ProcessBuilderServerDefinition("bsl,os", process);
+    ```
+> **Note:** All of the above implementations will use server stdin/stdout to communicate.
 
 ![](resources/images/lang-server-connect.gif)
    

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ group = "org.wso2.lsp4intellij"
 version = gitVersionCalculator.calculateVersion("v")
 
 intellij {
-    version '2020.1'
+    version '2021.1'
     type 'IC'
     updateSinceUntilBuild false
 }

--- a/build.gradle
+++ b/build.gradle
@@ -31,12 +31,12 @@ intellij {
 
 dependencies {
     compile group: 'org.eclipse.lsp4j', name: 'org.eclipse.lsp4j', version: '0.10.0'
-    compile group: 'com.vladsch.flexmark', name: 'flexmark', version: '0.34.58'
-    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.4'
-    testCompile group: 'junit', name: 'junit', version: '4.11'
-    testCompile group: 'org.mockito', name: 'mockito-core', version: '3.3.3'
-    testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.5'
-    testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.5'
+    compile group: 'com.vladsch.flexmark', name: 'flexmark', version: '0.34.60'
+    compile group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
+    testCompile group: 'junit', name: 'junit', version: '4.13.2'
+    testCompile group: 'org.mockito', name: 'mockito-core', version: '3.9.0'
+    testCompile group: 'org.powermock', name: 'powermock-api-mockito2', version: '2.0.9'
+    testCompile group: 'org.powermock', name: 'powermock-module-junit4', version: '2.0.9'
 }
 
 sourceSets {

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "jacoco"
-    id "org.jetbrains.intellij" version "0.4.9"
+    id "org.jetbrains.intellij" version "0.7.3"
     id "com.github.hierynomus.license" version "0.15.0"
     id "com.github.gradle-git-version-calculator" version "1.1.0"
     id 'net.researchgate.release' version '2.6.0'
@@ -12,6 +12,12 @@ plugins {
 
 repositories {
     mavenCentral()
+}
+
+tasks{
+    runPluginVerifier {
+        ideVersions = "2021.1"
+    }
 }
 
 group = "org.wso2.lsp4intellij"
@@ -40,6 +46,9 @@ sourceSets {
         }
     }
 }
+
+sourceCompatibility = 11
+targetCompatibility = 11
 
 license {
     header = rootProject.file("resources/license/HEADER.txt")

--- a/resources/plugin.xml.example
+++ b/resources/plugin.xml.example
@@ -14,8 +14,9 @@ see also jetbrains documentation: https://plugins.jetbrains.com/docs/intellij/pl
     <extensions defaultExtensionNs="com.intellij">
         <!-- register a preloading activity. You need to init IntellijLanguageClient with your config, see readme -->
         <preloadingActivity implementation="your.plugin.MyPreloadingActivity" id="your.plugin.MyPreloadingActivity"/>
-        <!-- future refactoring: Use service based architecture -->
-        <!-- <applicationService serviceImplementation="org.wso2.lsp4intellij.IntellijLanguageClient"/> -->
+
+        <!-- register intellijLanguageClient as a Service OR as a plugin component (see readme)... -->
+        <applicationService serviceImplementation="org.wso2.lsp4intellij.IntellijLanguageClient"/>
 
         <!-- register a listener on editor events, required for lsp file sync -->
         <editorFactoryListener implementation="org.wso2.lsp4intellij.listeners.LSPEditorListener"/>

--- a/resources/plugin.xml.example
+++ b/resources/plugin.xml.example
@@ -1,0 +1,69 @@
+<!--
+an example how you can configure an plugin xml with you plugin
+see also jetbrains documentation: https://plugins.jetbrains.com/docs/intellij/plugin-configuration-file.html -->
+<idea-plugin>
+    <id>your.plugin.namespace</id>
+    <name>Your Plugin Name</name>
+    <vendor>your company/org</vendor>
+    <description>a description of your plugin</description>
+
+    <!-- Product and plugin compatibility requirements -->
+    <!-- https://www.jetbrains.org/intellij/sdk/docs/basics/getting_started/plugin_compatibility.html -->
+    <depends>com.intellij.modules.platform</depends>
+
+    <extensions defaultExtensionNs="com.intellij">
+        <!-- register a preloading activity. You need to init IntellijLanguageClient with your config, see readme -->
+        <preloadingActivity implementation="your.plugin.MyPreloadingActivity" id="your.plugin.MyPreloadingActivity"/>
+        <!-- future refactoring: Use service based architecture -->
+        <!-- <applicationService serviceImplementation="org.wso2.lsp4intellij.IntellijLanguageClient"/> -->
+
+        <!-- register a listener on editor events, required for lsp file sync -->
+        <editorFactoryListener implementation="org.wso2.lsp4intellij.listeners.LSPEditorListener"/>
+        <fileDocumentManagerListener implementation="org.wso2.lsp4intellij.listeners.LSPFileDocumentManagerListener"/>
+
+        <!-- for displaying notifications by lsp -->
+        <notificationGroup id="lsp" displayType="STICKY_BALLOON"/>
+
+        <!-- for displaying the statusbar icon -->
+        <statusBarWidgetFactory implementation="org.wso2.lsp4intellij.statusbar.LSPServerStatusWidgetFactory"
+                                id="org.wso2.lsp4intellij.statusbar.LSPServerStatusWidgetFactory"
+                                order="first" />
+
+        <!-- needed for completion -->
+        <completion.contributor implementationClass="org.wso2.lsp4intellij.contributors.LSPCompletionContributor"
+                                id="org.wso2.lsp4intellij.contributors.LSPCompletionContributor" language="YOUR_LANGUAGE_ID"/>
+        <!-- needed for completion as well as signature help -->
+        <typedHandler implementation="org.wso2.lsp4intellij.listeners.LSPTypedHandler"
+                      id="LSPTypedHandler"/>
+
+        <!-- needed for code diagnostics -->
+        <externalAnnotator id="LSPAnnotator" language="YOUR_LANGUAGE_ID"
+                           implementationClass="org.wso2.lsp4intellij.contributors.annotator.LSPAnnotator"/>
+
+        <!-- needed for Workspace Symbols -->
+        <gotoSymbolContributor implementation="org.wso2.lsp4intellij.contributors.symbol.LSPSymbolContributor"
+                                     id="LSPSymbolContributor"/>
+
+        <!-- needed for renaming -->
+        <renameHandler implementation="org.wso2.lsp4intellij.contributors.rename.LSPRenameHandler" id="LSPRenameHandler" order="first"/>
+        <renamePsiElementProcessor implementation="org.wso2.lsp4intellij.contributors.rename.LSPRenameProcessor" id="LSPRenameProcessor" order="first"/>
+    </extensions>
+
+    <actions>
+        <!-- needed for hover -->
+        <action id="org.intellij.sdk.action.QuickDocAction" class="org.wso2.lsp4intellij.actions.LSPQuickDocAction">
+        </action>
+
+        <!-- needed for find references -->
+        <action class="org.wso2.lsp4intellij.actions.LSPReferencesAction" id="LSPFindUsages">
+             <keyboard-shortcut first-keystroke="shift alt F7" keymap="$default"/>
+        </action>
+    </actions>
+    <applicationListeners>
+        <!-- required for lsp file sync -->
+        <listener class="org.wso2.lsp4intellij.listeners.VFSListener"
+                  topic="com.intellij.openapi.vfs.VirtualFileListener"/>
+        <listener class="org.wso2.lsp4intellij.listeners.LSPProjectManagerListener"
+                  topic="com.intellij.openapi.project.ProjectManagerListener"/>
+    </applicationListeners>
+</idea-plugin>

--- a/src/main/java/org/wso2/lsp4intellij/actions/LSPReferencesAction.java
+++ b/src/main/java/org/wso2/lsp4intellij/actions/LSPReferencesAction.java
@@ -64,7 +64,7 @@ public class LSPReferencesAction extends DumbAwareAction {
             Pair<List<PsiElement>, List<VirtualFile>> references = eventManager
                     .references(editor.getCaretModel().getCurrentCaret().getOffset());
             if (references.first != null && references.second != null) {
-                references.first.forEach(element -> targets.add(new PsiElement2UsageTargetAdapter(element)));
+                references.first.forEach(element -> targets.add(new PsiElement2UsageTargetAdapter(element, true)));
             }
             showReferences(editor, targets, editor.getCaretModel().getCurrentCaret().getLogicalPosition());
         }
@@ -74,7 +74,7 @@ public class LSPReferencesAction extends DumbAwareAction {
         List<PsiElement2UsageTargetAdapter> targets = new ArrayList<>();
         Pair<List<PsiElement>, List<VirtualFile>> references = manager.references(offset);
         if (references.first != null && references.second != null) {
-            references.first.forEach(element -> targets.add(new PsiElement2UsageTargetAdapter(element)));
+            references.first.forEach(element -> targets.add(new PsiElement2UsageTargetAdapter(element, true)));
         }
         Editor editor = manager.editor;
         showReferences(editor, targets, editor.offsetToLogicalPosition(offset));
@@ -118,7 +118,7 @@ public class LSPReferencesAction extends DumbAwareAction {
         String scopeString = options.searchScope.getDisplayName();
         presentation.setScopeText(scopeString);
         String usagesString = options.generateUsagesString();
-        presentation.setUsagesString(usagesString);
+        presentation.setSearchString(usagesString);
         String title = FindBundle.message("find.usages.of.element.in.scope.panel.title", usagesString,
                 UsageViewUtil.getLongName(psiElement), scopeString);
         presentation.setTabText(title);

--- a/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
@@ -15,7 +15,11 @@
  */
 package org.wso2.lsp4intellij.client;
 
-import com.intellij.notification.*;
+import com.intellij.notification.Notification;
+import com.intellij.notification.NotificationAction;
+import com.intellij.notification.NotificationGroup;
+import com.intellij.notification.NotificationGroupManager;
+import com.intellij.notification.NotificationType;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
@@ -42,8 +46,7 @@ public class DefaultLanguageClient implements LanguageClient {
     @NotNull
     final private Logger LOG = Logger.getInstance(DefaultLanguageClient.class);
     @NotNull
-    private final NotificationGroup STICKY_NOTIFICATION_GROUP =
-            new NotificationGroup("lsp.message.request", NotificationDisplayType.STICKY_BALLOON, false);
+    private final NotificationGroup STICKY_NOTIFICATION_GROUP = NotificationGroupManager.getInstance().getNotificationGroup("lsp");
     @NotNull
     final private Map<String, DynamicRegistrationMethods> registrations = new ConcurrentHashMap<>();
     @NotNull
@@ -264,10 +267,5 @@ public class DefaultLanguageClient implements LanguageClient {
     @NotNull
     protected final ClientContext getContext() {
         return context;
-    }
-
-    @Override
-    public void semanticHighlighting(SemanticHighlightingParams params) {
-        // Todo
     }
 }

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/ServerOptions.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/ServerOptions.java
@@ -40,7 +40,6 @@ public class ServerOptions {
     public DocumentOnTypeFormattingOptions documentOnTypeFormattingOptions;
     public DocumentLinkOptions documentLinkOptions;
     public ExecuteCommandOptions executeCommandOptions;
-    public SemanticHighlightingServerCapabilities semanticHighlightingOptions;
 
     public ServerOptions(ServerCapabilities serverCapabilities) {
 
@@ -58,6 +57,5 @@ public class ServerOptions {
         this.documentOnTypeFormattingOptions = capabilities.getDocumentOnTypeFormattingProvider();
         this.documentLinkOptions = capabilities.getDocumentLinkProvider();
         this.executeCommandOptions = capabilities.getExecuteCommandProvider();
-        this.semanticHighlightingOptions = capabilities.getSemanticHighlighting();
     }
 }

--- a/src/main/java/org/wso2/lsp4intellij/contributors/LSPCompletionContributor.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/LSPCompletionContributor.java
@@ -23,18 +23,14 @@ import com.intellij.codeInsight.completion.PlainPrefixMatcher;
 import com.intellij.openapi.application.ex.ApplicationUtil;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.fileEditor.FileEditorManager;
 import com.intellij.openapi.progress.ProcessCanceledException;
 import com.intellij.openapi.progress.ProgressIndicatorProvider;
-import com.intellij.openapi.vfs.VirtualFile;
-import com.intellij.psi.PsiElement;
 import com.intellij.util.ProcessingContext;
 import org.eclipse.lsp4j.Position;
 import org.jetbrains.annotations.NotNull;
 import org.wso2.lsp4intellij.editor.EditorEventManager;
 import org.wso2.lsp4intellij.editor.EditorEventManagerBase;
 import org.wso2.lsp4intellij.utils.DocumentUtils;
-import org.wso2.lsp4intellij.utils.FileUtils;
 
 /**
  * The completion contributor for the LSP
@@ -81,25 +77,5 @@ class LSPCompletionContributor extends CompletionContributor {
 
             super.fillCompletionVariants(parameters, result);
         }
-    }
-
-    @Override
-    public boolean invokeAutoPopup(@NotNull PsiElement position, char typeChar) {
-        final VirtualFile file = position.getContainingFile().getVirtualFile();
-        if (!FileUtils.isFileSupported(file)) {
-            return false;
-        }
-
-        Editor editor = FileEditorManager.getInstance(position.getProject()).getSelectedTextEditor();
-        EditorEventManager manager = EditorEventManagerBase.forEditor(editor);
-        if (editor == null || manager == null) {
-            return false;
-        }
-        for (String triggerChar : manager.completionTriggers) {
-            if (triggerChar != null && triggerChar.length() == 1 && triggerChar.charAt(0) == typeChar) {
-                return true;
-            }
-        }
-        return false;
     }
 }

--- a/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
@@ -133,9 +133,9 @@ public class LSPAnnotator extends ExternalAnnotator<Object, Object> {
             return;
         }
         annotations.forEach(annotation -> {
-            // TODO: Use 'newAnnotation'; 'createAnnotation' is deprecated.
-            Annotation anon = holder.createAnnotation(annotation.getSeverity(),
-                    new TextRange(annotation.getStartOffset(), annotation.getEndOffset()), annotation.getMessage());
+            holder.newAnnotation(annotation.getSeverity(), annotation.getMessage());
+            SmartList<Annotation> asList = (SmartList<Annotation>) holder;
+            Annotation anon = asList.get(asList.size() - 1);
 
             if (annotation.getQuickFixes() == null || annotation.getQuickFixes().isEmpty()) {
                 return;

--- a/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
@@ -25,7 +25,6 @@ import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
-import com.intellij.util.SmartList;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.DiagnosticTag;
@@ -133,9 +132,7 @@ public class LSPAnnotator extends ExternalAnnotator<Object, Object> {
             return;
         }
         annotations.forEach(annotation -> {
-            holder.newAnnotation(annotation.getSeverity(), annotation.getMessage());
-            SmartList<Annotation> asList = (SmartList<Annotation>) holder;
-            Annotation anon = asList.get(asList.size() - 1);
+            Annotation anon = holder.newAnnotation(annotation.getSeverity(), annotation.getMessage()).createAnnotation();
 
             if (annotation.getQuickFixes() == null || annotation.getQuickFixes().isEmpty()) {
                 return;
@@ -153,12 +150,9 @@ public class LSPAnnotator extends ExternalAnnotator<Object, Object> {
         }
         final TextRange range = new TextRange(start, end);
 
-        holder.newAnnotation(lspToIntellijAnnotationsMap.get(diagnostic.getSeverity()), diagnostic.getMessage())
+        return holder.newAnnotation(lspToIntellijAnnotationsMap.get(diagnostic.getSeverity()), diagnostic.getMessage())
                 .range(range)
-                .create();
-
-        SmartList<Annotation> asList = (SmartList<Annotation>) holder;
-        return asList.get(asList.size() - 1);
+                .createAnnotation();
     }
 
     private void createAnnotations(AnnotationHolder holder, EditorEventManager eventManager) {

--- a/src/main/java/org/wso2/lsp4intellij/contributors/icon/LSPDefaultIconProvider.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/icon/LSPDefaultIconProvider.java
@@ -30,9 +30,9 @@ import javax.swing.Icon;
 
 public class LSPDefaultIconProvider extends LSPIconProvider {
 
-    private static Icon GREEN = IconLoader.getIcon("/images/started.png");
-    private static Icon YELLOW = IconLoader.getIcon("/images/starting.png");
-    private static Icon RED = IconLoader.getIcon("/images/stopped.png");
+    private final static Icon GREEN = IconLoader.getIcon("/images/started.png", LSPDefaultIconProvider.class);
+    private final static Icon YELLOW = IconLoader.getIcon("/images/starting.png", LSPDefaultIconProvider.class);
+    private final static Icon RED = IconLoader.getIcon("/images/stopped.png", LSPDefaultIconProvider.class);
 
     public Icon getCompletionIcon(CompletionItemKind kind) {
 

--- a/src/main/java/org/wso2/lsp4intellij/contributors/rename/LSPRenameHandler.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/rename/LSPRenameHandler.java
@@ -31,7 +31,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.psi.PsiNameIdentifierOwner;
 import com.intellij.psi.PsiNamedElement;
-import com.intellij.psi.impl.source.tree.injected.InjectedLanguageUtil;
+import com.intellij.psi.impl.source.tree.injected.InjectedLanguageEditorUtil;
 import com.intellij.refactoring.rename.PsiElementRenameHandler;
 import com.intellij.refactoring.rename.RenameHandler;
 import com.intellij.refactoring.rename.RenamePsiElementProcessor;
@@ -45,6 +45,8 @@ import org.wso2.lsp4intellij.editor.EditorEventManager;
 import org.wso2.lsp4intellij.editor.EditorEventManagerBase;
 
 import java.util.List;
+
+import static com.intellij.openapi.command.impl.StartMarkAction.START_MARK_ACTION_KEY;
 
 /**
  * The LSP based rename handler implementation.
@@ -78,7 +80,7 @@ public class LSPRenameHandler implements RenameHandler {
         if (elementToRename instanceof PsiNameIdentifierOwner) {
             RenamePsiElementProcessor processor = RenamePsiElementProcessor.forElement(elementToRename);
             if (processor.isInplaceRenameSupported()) {
-                StartMarkAction startMarkAction = StartMarkAction.canStart(elementToRename.getProject());
+                StartMarkAction startMarkAction = editor.getUserData(START_MARK_ACTION_KEY);
                 if (startMarkAction == null || (processor.substituteElementToRename(elementToRename, editor)
                         == elementToRename)) {
                     processor.substituteElementToRename(elementToRename, editor, new Pass<PsiElement>() {
@@ -98,7 +100,7 @@ public class LSPRenameHandler implements RenameHandler {
                 InplaceRefactoring inplaceRefactoring = editor.getUserData(InplaceRefactoring.INPLACE_RENAMER);
                 if ((inplaceRefactoring instanceof MemberInplaceRenamer)) {
                     TemplateState templateState = TemplateManagerImpl
-                            .getTemplateState(InjectedLanguageUtil.getTopLevelEditor(editor));
+                            .getTemplateState(InjectedLanguageEditorUtil.getTopLevelEditor(editor));
                     if (templateState != null) {
                         templateState.gotoEnd(true);
                     }

--- a/src/main/java/org/wso2/lsp4intellij/contributors/rename/LSPRenameProcessor.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/rename/LSPRenameProcessor.java
@@ -63,33 +63,6 @@ public class LSPRenameProcessor extends RenamePsiElementProcessor {
     }
 
     @NotNull
-    @Override
-    public Collection<PsiReference> findReferences(@NotNull PsiElement element) {
-        return findReferences(element, false);
-    }
-
-    // Todo - remove and change the minimum compatible version to IDEA 2019.2, once this deprecated method is removed.
-    @NotNull
-    @SuppressWarnings("unused")
-    public Collection<PsiReference> findReferences(@NotNull PsiElement element, boolean searchInCommentsAndStrings) {
-        if (element instanceof LSPPsiElement) {
-            if (elements.contains(element)) {
-                return elements.stream().map(PsiElement::getReference).filter(Objects::nonNull).collect(Collectors.toList());
-            } else {
-                EditorEventManager manager = EditorEventManagerBase.forEditor(FileUtils.editorFromPsiFile(element.getContainingFile()));
-                if (manager != null) {
-                    Pair<List<PsiElement>, List<VirtualFile>> refs = manager.references(element.getTextOffset(), true, false);
-                    if (refs.getFirst() != null && refs.getSecond() != null) {
-                        addEditors(refs.getSecond());
-                        return refs.getFirst().stream().map(PsiElement::getReference).filter(Objects::nonNull).collect(Collectors.toList());
-                    }
-                }
-            }
-        }
-        return new ArrayList<>();
-    }
-
-    @NotNull
     @SuppressWarnings("unused")
     public Collection<PsiReference> findReferences(@NotNull PsiElement element, @NotNull SearchScope searchScope,
                                                    boolean searchInCommentsAndStrings) {

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -202,7 +202,7 @@ public class EditorEventManager {
     private volatile boolean diagnosticSyncRequired = true;
     private volatile boolean codeActionSyncRequired = false;
 
-    private static final long CTRL_THRESH = EditorSettingsExternalizable.getInstance().getQuickDocOnMouseOverElementDelayMillis() * 1000000;
+    private static final long CTRL_THRESH = EditorSettingsExternalizable.getInstance().getTooltipsDelay() * 1000000;
 
     public static final String SNIPPET_PLACEHOLDER_REGEX = "(\\$\\{\\d+:?([^{^}]*)}|\\$\\d+)";
 

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -71,10 +71,8 @@ import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.DefinitionParams;
 import org.eclipse.lsp4j.Diagnostic;
-import org.eclipse.lsp4j.DidChangeTextDocumentParams;
-import org.eclipse.lsp4j.DidCloseTextDocumentParams;
-import org.eclipse.lsp4j.DidOpenTextDocumentParams;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
 import org.eclipse.lsp4j.DocumentFormattingParams;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
@@ -92,9 +90,9 @@ import org.eclipse.lsp4j.ReferenceContext;
 import org.eclipse.lsp4j.ReferenceParams;
 import org.eclipse.lsp4j.RenameParams;
 import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureHelpParams;
 import org.eclipse.lsp4j.SignatureInformation;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
-import org.eclipse.lsp4j.TextDocumentPositionParams;
 import org.eclipse.lsp4j.TextDocumentSaveReason;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.TextEdit;
@@ -396,7 +394,7 @@ public class EditorEventManager {
      * @return The location of the definition
      */
     private Location requestDefinition(Position position) {
-        TextDocumentPositionParams params = new TextDocumentPositionParams(identifier, position);
+        DefinitionParams params = new DefinitionParams(identifier, position);
         CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>> request =
                 wrapper.getRequestManager().definition(params);
 
@@ -437,7 +435,8 @@ public class EditorEventManager {
      */
     public Pair<List<PsiElement>, List<VirtualFile>> references(int offset, boolean getOriginalElement, boolean close) {
         Position lspPos = DocumentUtils.offsetToLSPPos(editor, offset);
-        ReferenceParams params = new ReferenceParams(new ReferenceContext(getOriginalElement));
+        TextDocumentIdentifier textDocumentIdentifier = new TextDocumentIdentifier(FileUtils.editorToURIString(editor));
+        ReferenceParams params = new ReferenceParams(textDocumentIdentifier, lspPos, new ReferenceContext(getOriginalElement));
         params.setPosition(lspPos);
         params.setTextDocument(identifier);
         CompletableFuture<List<? extends Location>> request = wrapper.getRequestManager().references(params);
@@ -603,7 +602,7 @@ public class EditorEventManager {
         }
         LogicalPosition lPos = editor.getCaretModel().getCurrentCaret().getLogicalPosition();
         Point point = editor.logicalPositionToXY(lPos);
-        TextDocumentPositionParams params = new TextDocumentPositionParams(identifier, DocumentUtils.logicalToLSPPos(lPos, editor));
+        SignatureHelpParams params = new SignatureHelpParams(identifier, DocumentUtils.logicalToLSPPos(lPos, editor));
         pool(() -> {
             CompletableFuture<SignatureHelp> future = wrapper.getRequestManager().signatureHelp(params);
             if (future == null) {

--- a/src/main/java/org/wso2/lsp4intellij/listeners/LSPTypedHandler.java
+++ b/src/main/java/org/wso2/lsp4intellij/listeners/LSPTypedHandler.java
@@ -44,7 +44,7 @@ public class LSPTypedHandler extends TypedHandlerDelegate {
     }
 
     @Override
-    public @NotNull Result checkAutoPopup(char charTyped, @NotNull Project project, @NotNull Editor editor, @NotNull PsiFile file) {
+    public Result checkAutoPopup(char charTyped, @NotNull Project project, @NotNull Editor editor, @NotNull PsiFile file) {
         if (!FileUtils.isFileSupported(file.getVirtualFile())) {
             return Result.CONTINUE;
         }

--- a/src/main/java/org/wso2/lsp4intellij/listeners/LSPTypedHandler.java
+++ b/src/main/java/org/wso2/lsp4intellij/listeners/LSPTypedHandler.java
@@ -15,6 +15,7 @@
  */
 package org.wso2.lsp4intellij.listeners;
 
+import com.intellij.codeInsight.AutoPopupController;
 import com.intellij.codeInsight.editorActions.TypedHandlerDelegate;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.project.Project;
@@ -38,6 +39,24 @@ public class LSPTypedHandler extends TypedHandlerDelegate {
         EditorEventManager eventManager = EditorEventManagerBase.forEditor(editor);
         if (eventManager != null) {
             eventManager.characterTyped(c);
+        }
+        return Result.CONTINUE;
+    }
+
+    @Override
+    public @NotNull Result checkAutoPopup(char charTyped, @NotNull Project project, @NotNull Editor editor, @NotNull PsiFile file) {
+        if (!FileUtils.isFileSupported(file.getVirtualFile())) {
+            return Result.CONTINUE;
+        }
+
+        EditorEventManager manager = EditorEventManagerBase.forEditor(editor);
+        if (manager == null) {
+            return Result.CONTINUE;
+        }
+        for (String triggerChar : manager.completionTriggers) {
+            if (triggerChar != null && triggerChar.length() == 1 && triggerChar.charAt(0) == charTyped) {
+                return Result.STOP;
+            }
         }
         return Result.CONTINUE;
     }

--- a/src/main/java/org/wso2/lsp4intellij/statusbar/LSPServerStatusWidgetFactory.java
+++ b/src/main/java/org/wso2/lsp4intellij/statusbar/LSPServerStatusWidgetFactory.java
@@ -49,15 +49,9 @@ public class LSPServerStatusWidgetFactory implements StatusBarWidgetFactory {
     }
 
     @Override
-    public @NotNull
+    public
     StatusBarWidget createWidget(@NotNull Project project) {
-        if (widgetForProject.containsKey(project)) {
-            return widgetForProject.get(project);
-        }
-        LSPServerStatusWidget widget = new LSPServerStatusWidget(project);
-
-        widgetForProject.put(project, widget);
-        return widget;
+        return widgetForProject.computeIfAbsent(project, (k) -> new LSPServerStatusWidget(project));
     }
 
     @Override

--- a/src/main/java/org/wso2/lsp4intellij/statusbar/LSPServerStatusWidgetFactory.java
+++ b/src/main/java/org/wso2/lsp4intellij/statusbar/LSPServerStatusWidgetFactory.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright (c) 2021, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.wso2.lsp4intellij.statusbar;
 
 import com.intellij.openapi.project.Project;

--- a/src/main/java/org/wso2/lsp4intellij/statusbar/LSPServerStatusWidgetFactory.java
+++ b/src/main/java/org/wso2/lsp4intellij/statusbar/LSPServerStatusWidgetFactory.java
@@ -1,0 +1,63 @@
+package org.wso2.lsp4intellij.statusbar;
+
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.wm.StatusBar;
+import com.intellij.openapi.wm.StatusBarWidget;
+import com.intellij.openapi.wm.StatusBarWidgetFactory;
+import org.jetbrains.annotations.Nls;
+import org.jetbrains.annotations.NonNls;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class LSPServerStatusWidgetFactory implements StatusBarWidgetFactory {
+    private final Map<Project, LSPServerStatusWidget> widgetForProject = new HashMap<>();
+
+    @Override
+    public @NonNls
+    @NotNull
+    String getId() {
+        return "LSP";
+    }
+
+    @Override
+    public @Nls
+    @NotNull
+    String getDisplayName() {
+        return "Language Server";
+    }
+
+    @Override
+    public boolean isAvailable(@NotNull Project project) {
+        return true;
+    }
+
+    @Override
+    public @NotNull
+    StatusBarWidget createWidget(@NotNull Project project) {
+        if (widgetForProject.containsKey(project)) {
+            return widgetForProject.get(project);
+        }
+        LSPServerStatusWidget widget = new LSPServerStatusWidget(project);
+
+        widgetForProject.put(project, widget);
+        return widget;
+    }
+
+    @Override
+    public void disposeWidget(@NotNull StatusBarWidget statusBarWidget) {
+        if (statusBarWidget instanceof LSPServerStatusWidget) {
+            widgetForProject.remove(((LSPServerStatusWidget) statusBarWidget).getProject());
+        }
+    }
+
+    @Override
+    public boolean canBeEnabledOn(@NotNull StatusBar statusBar) {
+        return true;
+    }
+
+    public LSPServerStatusWidget getWidget(Project project) {
+        return widgetForProject.get(project);
+    }
+}

--- a/src/test/java/org/wso2/lsp4intellij/utils/FileUtilsTest.java
+++ b/src/test/java/org/wso2/lsp4intellij/utils/FileUtilsTest.java
@@ -60,7 +60,7 @@ public class FileUtilsTest {
         PowerMockito.when(fileEditorManagerEx.getAllEditors(file))
                 .thenReturn(new FileEditor[]{textEditor})
                 .thenReturn(new FileEditor[0]);
-        PowerMockito.when(FileEditorManager.getInstance(project)).thenReturn(fileEditorManagerEx);
+        PowerMockito.when(FileEditorManager.getInstance(project)).thenAnswer(invocation -> fileEditorManagerEx);
 
         Assert.assertEquals(editor, FileUtils.editorFromVirtualFile(file, project));
 
@@ -175,7 +175,7 @@ public class FileUtilsTest {
         PowerMockito.spy(FileUtils.class);
         Project project = PowerMockito.mock(Project.class);
         PowerMockito.when(project.getBasePath()).thenReturn("test");
-        PowerMockito.when(FileUtils.pathToUri(Mockito.anyString())).thenReturn("fooBar");
+        PowerMockito.when(FileUtils.pathToUri(Mockito.anyString())).thenAnswer(invocation -> "fooBar");
 
         Assert.assertEquals("fooBar", FileUtils.projectToUri(project));
     }
@@ -203,7 +203,7 @@ public class FileUtilsTest {
         PowerMockito.mockStatic(FileDocumentManager.class);
         FileDocumentManager fileDocumentManager = PowerMockito.mock(FileDocumentManager.class);
         PowerMockito.when(fileDocumentManager.getFile(Mockito.mock(Document.class))).thenReturn(virtualFile1);
-        PowerMockito.when(FileDocumentManager.getInstance()).thenReturn(fileDocumentManager);
+        PowerMockito.when(FileDocumentManager.getInstance()).thenAnswer(invocation -> fileDocumentManager);
 
         Assert.assertFalse(FileUtils.isEditorSupported(Mockito.mock(Editor.class)));
     }


### PR DESCRIPTION
this resolves #190, #189, #184

and prepares for #192, #175

NOTE: This also raises the minimum IJ version to 2021.1 and Java version to 11!

I've also adjusted parts of the documentation, which i hope is clearer now.

Note that the plugin.xml-setup is now more complex, as all the listerners get to be defined in the xml instead of IntellijLanguageClient. I've added an example to cover that. Also i deprecated the Plugin-Components approach in the documentation  (which should still work however)

Note that i did not test all changes, as my Language server does not cover all use cases. I believe however that these changes are minor and hopefully work.

To cover #175 & #192 we need to use Services, which should be easy to do however, they just need to be registered in plugin.xml. We also probably should not store stuff in static variables, in order to be compatible/avoid memleaks, so there is some work to be done.
