### PR TITLE
Implement file type defnition mapping

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -271,15 +271,17 @@ public class IntellijLanguageClient implements ApplicationComponent, Disposable 
             if (serverDefinition == null) {
                 ImmutablePair<Class<? extends FileType>, String> key = new ImmutablePair<>(type.getClass(), projectUri);
                 serverDefinition = fileTypeToServerDefinition.get(key);
+                if(serverDefinition != null) {
+                    ext = serverDefinition.ext;
+                }
             }
 
             if (serverDefinition == null) {
                 ImmutablePair<Class<? extends FileType>, String> key = new ImmutablePair<>(type.getClass(), "");
                 serverDefinition = fileTypeToServerDefinition.get(key);
-            }
-
-            if(serverDefinition != null && (ext == null || ext.equals(""))) {
-                ext = serverDefinition.ext;
+                if(serverDefinition != null) {
+                    ext = serverDefinition.ext;
+                }
             }
 
             if (serverDefinition == null) {

--- a/src/main/java/org/wso2/lsp4intellij/actions/LSPReformatAction.java
+++ b/src/main/java/org/wso2/lsp4intellij/actions/LSPReformatAction.java
@@ -25,8 +25,8 @@ import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
-import org.wso2.lsp4intellij.IntellijLanguageClient;
 import org.wso2.lsp4intellij.requests.ReformatHandler;
+import org.wso2.lsp4intellij.utils.FileUtils;
 
 /**
  * Action overriding the default reformat action
@@ -43,8 +43,8 @@ public class LSPReformatAction extends ReformatCodeAction implements DumbAware {
             return;
         }
         PsiFile file = PsiDocumentManager.getInstance(project).getPsiFile(editor.getDocument());
-        if (LanguageFormatting.INSTANCE.allForLanguage(file.getLanguage()).isEmpty() && IntellijLanguageClient
-                .isExtensionSupported(file.getVirtualFile())) {
+        if (LanguageFormatting.INSTANCE.allForLanguage(file.getLanguage()).isEmpty() && FileUtils
+                .isFileSupported(file.getVirtualFile())) {
             // if editor hasSelection, only reformat selection, not reformat the whole file
             if (editor.getSelectionModel().hasSelection()) {
                 ReformatHandler.reformatSelection(editor);

--- a/src/main/java/org/wso2/lsp4intellij/actions/LSPShowReformatDialogAction.java
+++ b/src/main/java/org/wso2/lsp4intellij/actions/LSPShowReformatDialogAction.java
@@ -30,9 +30,9 @@ import com.intellij.openapi.project.Project;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiFile;
-import org.wso2.lsp4intellij.IntellijLanguageClient;
 import org.wso2.lsp4intellij.editor.EditorEventManager;
 import org.wso2.lsp4intellij.editor.EditorEventManagerBase;
+import org.wso2.lsp4intellij.utils.FileUtils;
 
 /**
  * Class overriding the default action handling the Reformat dialog event (CTRL+ALT+SHIFT+L by default)
@@ -51,7 +51,7 @@ public class LSPShowReformatDialogAction extends ShowReformatFileDialog implemen
             PsiFile psiFile = PsiDocumentManager.getInstance(project).getPsiFile(editor.getDocument());
             VirtualFile virFile = FileDocumentManager.getInstance().getFile(editor.getDocument());
             boolean alreadySupported = !LanguageFormatting.INSTANCE.allForLanguage(psiFile.getLanguage()).isEmpty();
-            if (!alreadySupported && IntellijLanguageClient.isExtensionSupported(virFile)) {
+            if (!alreadySupported && FileUtils.isFileSupported(virFile)) {
                 boolean hasSelection = editor.getSelectionModel().hasSelection();
                 LayoutCodeDialog dialog = new LayoutCodeDialog(project, psiFile, hasSelection, HELP_ID);
                 dialog.show();

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/LanguageServerDefinition.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/LanguageServerDefinition.java
@@ -16,8 +16,10 @@
 package org.wso2.lsp4intellij.client.languageserver.serverdefinition;
 
 import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.vfs.VirtualFile;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.jetbrains.annotations.NotNull;
 import org.wso2.lsp4intellij.client.connection.StreamConnectionProvider;
 
 import java.io.IOException;
@@ -100,8 +102,17 @@ public class LanguageServerDefinition {
     /**
      * Return language id for the given extension. if there is no langauge ids registered then the
      * return value will be the value of <code>extension</code>.
+     * @param file is the file to get the language id for
      */
-    public String languageIdFor(String extension) {
-        return languageIds.getOrDefault(extension, extension);
+    public String languageIdFor(@NotNull VirtualFile file) {
+        // TODO: probably makes sense to map file types to lang ids
+        String id = languageIds.get(file.getExtension());
+        if (id == null) {
+            id = file.getExtension();
+        }
+        if(id == null) {
+            id = ext;
+        }
+        return id;
     }
 }

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/TcpServerDefinition.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/TcpServerDefinition.java
@@ -1,0 +1,94 @@
+package org.wso2.lsp4intellij.client.languageserver.serverdefinition;
+
+import org.wso2.lsp4intellij.client.connection.StreamConnectionProvider;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.Socket;
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * TcpServerDefinition is a {@link LanguageServerDefinition} that connects to an LSP implementation over a TCP socket.
+ */
+@SuppressWarnings("unused")
+public class TcpServerDefinition extends LanguageServerDefinition {
+    private final TcpStreamConnectionProvider connectionProvider;
+
+    /**
+     * Creates a new TcpServerDefinition with no language IDs
+     *
+     * @param ext the extension this lsp definition is for
+     * @param host the host of the language server
+     * @param port the port of the language server
+     */
+    public TcpServerDefinition(String ext, String host, int port) {
+        this(ext, host, port, Collections.emptyMap());
+    }
+
+    /**
+     * Create a new TcpServerDefinition
+     *
+     * @param ext the extension this lsp definition is for
+     * @param host the host of the language server
+     * @param port the port of the language server
+     * @param langIds The language server ids mapping to extension(s).
+     */
+    public TcpServerDefinition(String ext, String host, int port, Map<String, String> langIds) {
+        this.languageIds = langIds;
+        this.ext = ext;
+
+        // We can do this upfront as we don't care about the working directory
+        connectionProvider = new TcpStreamConnectionProvider(host, port);
+    }
+
+    @Override
+    public StreamConnectionProvider createConnectionProvider(String workingDir) {
+        return connectionProvider;
+    }
+
+    private static class TcpStreamConnectionProvider implements StreamConnectionProvider {
+        private final String host;
+        private final int port;
+
+        private InputStream is;
+        private OutputStream os;
+
+        private Socket socket;
+
+        private TcpStreamConnectionProvider(String host, int port) {
+            this.host = host;
+            this.port = port;
+        }
+
+
+        @Override
+        public void start() throws IOException {
+            socket = new Socket(host, port);
+
+            // Do this here as these methods can throw IO exception, which we don't want to handle that in the getters
+            is = socket.getInputStream();
+            os = socket.getOutputStream();
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return is;
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return os;
+        }
+
+        @Override
+        public void stop() {
+            try {
+                socket.close();
+            } catch (IOException e) {
+               // ignore... nothing we (anybody?) can do about this
+            }
+        }
+    }
+}

--- a/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
@@ -31,7 +31,6 @@ import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.DiagnosticTag;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
-import org.wso2.lsp4intellij.IntellijLanguageClient;
 import org.wso2.lsp4intellij.client.languageserver.ServerStatus;
 import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
 import org.wso2.lsp4intellij.editor.EditorEventManager;
@@ -67,7 +66,7 @@ public class LSPAnnotator extends ExternalAnnotator<Object, Object> {
             VirtualFile virtualFile = file.getVirtualFile();
 
             // If the file is not supported, we skips the annotation by returning null.
-            if (!FileUtils.isFileSupported(virtualFile) || !IntellijLanguageClient.isExtensionSupported(virtualFile)) {
+            if (!FileUtils.isFileSupported(virtualFile) || !FileUtils.isFileSupported(virtualFile)) {
                 return null;
             }
             EditorEventManager eventManager = EditorEventManagerBase.forEditor(editor);
@@ -100,7 +99,7 @@ public class LSPAnnotator extends ExternalAnnotator<Object, Object> {
         }
 
         VirtualFile virtualFile = file.getVirtualFile();
-        if (FileUtils.isFileSupported(virtualFile) && IntellijLanguageClient.isExtensionSupported(virtualFile)) {
+        if (FileUtils.isFileSupported(virtualFile) && FileUtils.isFileSupported(virtualFile)) {
             String uri = FileUtils.VFSToURI(virtualFile);
             // TODO annotations are applied to a file / document not to an editor. so store them by file and not by editor..
             EditorEventManager eventManager = EditorEventManagerBase.forUri(uri);

--- a/src/main/java/org/wso2/lsp4intellij/contributors/rename/LSPRenameHandler.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/rename/LSPRenameHandler.java
@@ -39,10 +39,10 @@ import com.intellij.refactoring.rename.inplace.InplaceRefactoring;
 import com.intellij.refactoring.rename.inplace.MemberInplaceRenameHandler;
 import com.intellij.refactoring.rename.inplace.MemberInplaceRenamer;
 import org.jetbrains.annotations.NotNull;
-import org.wso2.lsp4intellij.IntellijLanguageClient;
 import org.wso2.lsp4intellij.contributors.psi.LSPPsiElement;
 import org.wso2.lsp4intellij.editor.EditorEventManager;
 import org.wso2.lsp4intellij.editor.EditorEventManagerBase;
+import org.wso2.lsp4intellij.utils.FileUtils;
 
 import java.util.List;
 
@@ -127,7 +127,7 @@ public class LSPRenameHandler implements RenameHandler {
         if (psiElement instanceof PsiFile || psiElement instanceof LSPPsiElement) {
             return true;
         } else {
-            return IntellijLanguageClient.isExtensionSupported(psiFile.getVirtualFile());
+            return FileUtils.isFileSupported(psiFile.getVirtualFile());
         }
     }
 

--- a/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
@@ -22,27 +22,14 @@ import com.intellij.openapi.editor.event.DocumentEvent;
 import com.intellij.openapi.editor.event.DocumentListener;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.util.text.StringUtil;
-import org.eclipse.lsp4j.DidChangeTextDocumentParams;
-import org.eclipse.lsp4j.DidCloseTextDocumentParams;
-import org.eclipse.lsp4j.DidOpenTextDocumentParams;
-import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.TextDocumentContentChangeEvent;
-import org.eclipse.lsp4j.TextDocumentIdentifier;
-import org.eclipse.lsp4j.TextDocumentItem;
-import org.eclipse.lsp4j.TextDocumentSyncKind;
-import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
-import org.wso2.lsp4intellij.client.languageserver.requestmanager.RequestManager;
+import com.intellij.openapi.vfs.VirtualFile;
+import org.eclipse.lsp4j.*;
 import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
 import org.wso2.lsp4intellij.utils.ApplicationUtils;
 import org.wso2.lsp4intellij.utils.DocumentUtils;
 import org.wso2.lsp4intellij.utils.FileUtils;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 
 public class DocumentEventManager {
     private final Document document;
@@ -152,9 +139,10 @@ public class DocumentEventManager {
             LOG.warn("trying to send open notification for document which was already opened!");
         } else {
             openDocuments.add(document);
-            final String extension = FileDocumentManager.getInstance().getFile(document).getExtension();
+            VirtualFile file = FileDocumentManager.getInstance().getFile(document);
+            String languageId = wrapper.serverDefinition.languageIdFor(file);
             wrapper.getRequestManager().didOpen(new DidOpenTextDocumentParams(new TextDocumentItem(identifier.getUri(),
-                    wrapper.serverDefinition.languageIdFor(extension),
+                    languageId,
                     ++version,
                     document.getText())));
         }

--- a/src/main/java/org/wso2/lsp4intellij/utils/FileUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/FileUtils.java
@@ -322,7 +322,7 @@ public class FileUtils {
             return false;
         }
 
-        return IntellijLanguageClient.isExtensionSupported(file);
+        return IntellijLanguageClient.isExtensionSupported(file) || IntellijLanguageClient.isFileTypeSupported(file);
     }
 
     /**


### PR DESCRIPTION
## Purpose
Resolves #252

## Goals
Lots of files don't have extension: `Makefile`, `Dockerfile`, and in my case: `BUILD`  files. Mapping a definition to a filetype also seems to fit into the Intellij framework better. 

## Approach
Added a new map to IntellijLanguageClient and added new API methods to register definitions against a filetype. 

## Release note
LanguageServerDefinitions can now be registered against file types with IntellijLanguageClient#addServerDefinition

