### PR TITLE
prevent null pointer exception if no managers are found when publishing diagnostics

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
@@ -112,8 +112,10 @@ public class DefaultLanguageClient implements LanguageClient {
         String uri = FileUtils.sanitizeURI(publishDiagnosticsParams.getUri());
         List<Diagnostic> diagnostics = publishDiagnosticsParams.getDiagnostics();
         Set<EditorEventManager> managers = EditorEventManagerBase.managersForUri(uri);
-        for (EditorEventManager manager: managers) {
-            manager.diagnostics(diagnostics);
+        if (managers != null) {
+            for (EditorEventManager manager : managers) {
+                manager.diagnostics(diagnostics);
+            }
         }
     }
 


### PR DESCRIPTION
## Purpose
> Prevent a possible exception when publishing diagnostics, fixes #281 

## Approach
> add a null check

## Release note
> fix null pointer exception that can occur when opening / closing files while the LSP is running

## Test environment
OSX
 