### PR TITLE
use a temporary variable too shutdown existing executor service

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/utils/ApplicationUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/ApplicationUtils.java
@@ -53,18 +53,21 @@ public class ApplicationUtils {
     }
 
     static public void restartPool() {
-        EXECUTOR_SERVICE.shutdown();
-        try {
-            EXECUTOR_SERVICE.awaitTermination(IntellijLanguageClient.getTimeout(Timeouts.SHUTDOWN), TimeUnit.MILLISECONDS);
-        } catch (InterruptedException ignored) {
-        }
+        ExecutorService esToShutdown = EXECUTOR_SERVICE;
         EXECUTOR_SERVICE = Executors.newSingleThreadExecutor();
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
                 EXECUTOR_SERVICE.shutdownNow();
             }
-        });    }
+        });
+
+        esToShutdown.shutdown();
+        try {
+            esToShutdown.awaitTermination(IntellijLanguageClient.getTimeout(Timeouts.SHUTDOWN), TimeUnit.MILLISECONDS);
+        } catch (InterruptedException ignored) {
+        }
+    }
 
     static public <T> T computableReadAction(Computable<T> computable) {
         return ApplicationManager.getApplication().runReadAction(computable);


### PR DESCRIPTION
## Purpose
> make new task scheduler available prior to shutting down existing one, fixes #282 

## Goals
> prevent RejectedExecutionException by ensuring the executor service is always available during startup / shutdown

## Approach
> store old executor service in a variable, instantiate new executor service, then shutdown old executor service

## Release note
> prevent LSP startup / shutdown RejectedExecutionException

## Test environment
> OSX