### PR TITLE
prevent null pointer exception with languageServerWrapper when opening / closing files

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
@@ -94,7 +94,8 @@ public class LSPAnnotator extends ExternalAnnotator<Object, Object> {
     @Override
     public void apply(@NotNull PsiFile file, Object annotationResult, @NotNull AnnotationHolder holder) {
 
-        if (LanguageServerWrapper.forVirtualFile(file.getVirtualFile(), file.getProject()).getStatus() != ServerStatus.INITIALIZED) {
+        LanguageServerWrapper languageServerWrapper = LanguageServerWrapper.forVirtualFile(file.getVirtualFile(), file.getProject());
+        if (languageServerWrapper == null || languageServerWrapper.getStatus() != ServerStatus.INITIALIZED) {
             return;
         }
 


### PR DESCRIPTION
## Purpose
> fix for #288 

## Goals
> prevent null pointer exception that occurs when opening / closing files

## Approach
> null check on LanguageServerWrapper

## Test environment
> OSX