### PR TITLE
prevent RejectedExecutionException by removing mechanism to restart executor server during LanguageServer stop

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -88,7 +88,6 @@ import org.wso2.lsp4intellij.listeners.EditorMouseMotionListenerImpl;
 import org.wso2.lsp4intellij.listeners.LSPCaretListenerImpl;
 import org.wso2.lsp4intellij.requests.Timeouts;
 import org.wso2.lsp4intellij.statusbar.LSPServerStatusWidgetFactory;
-import org.wso2.lsp4intellij.utils.ApplicationUtils;
 import org.wso2.lsp4intellij.utils.FileUtils;
 import org.wso2.lsp4intellij.utils.LSPException;
 
@@ -463,7 +462,6 @@ public class LanguageServerWrapper {
                 disconnect(ed);
             }
 
-            ApplicationUtils.restartPool();
             // sadly this whole editor closing stuff runs asynchronously, so we cannot be sure the state is really clean here...
             // therefore clear the mapping from here as it should be empty by now.
             DocumentEventManager.clearState();

--- a/src/main/java/org/wso2/lsp4intellij/utils/ApplicationUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/ApplicationUtils.java
@@ -16,20 +16,16 @@
 package org.wso2.lsp4intellij.utils;
 
 import com.intellij.openapi.application.ApplicationManager;
-import com.intellij.openapi.application.ModalityState;
 import com.intellij.openapi.project.NoAccessDuringPsiEvents;
 import com.intellij.openapi.util.Computable;
 import com.intellij.openapi.util.Condition;
-import org.wso2.lsp4intellij.IntellijLanguageClient;
-import org.wso2.lsp4intellij.requests.Timeouts;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 
 public class ApplicationUtils {
 
-    private static ExecutorService EXECUTOR_SERVICE;
+    private final static ExecutorService EXECUTOR_SERVICE;
 
     static {
         // Single threaded executor is used to simulate a behavior of async sequencial execution.
@@ -51,20 +47,6 @@ public class ApplicationUtils {
     static public void pool(Runnable runnable) {
         EXECUTOR_SERVICE.submit(runnable);
     }
-
-    static public void restartPool() {
-        EXECUTOR_SERVICE.shutdown();
-        try {
-            EXECUTOR_SERVICE.awaitTermination(IntellijLanguageClient.getTimeout(Timeouts.SHUTDOWN), TimeUnit.MILLISECONDS);
-        } catch (InterruptedException ignored) {
-        }
-        EXECUTOR_SERVICE = Executors.newSingleThreadExecutor();
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-            @Override
-            public void run() {
-                EXECUTOR_SERVICE.shutdownNow();
-            }
-        });    }
 
     static public <T> T computableReadAction(Computable<T> computable) {
         return ApplicationManager.getApplication().runReadAction(computable);


### PR DESCRIPTION
## Purpose
> fix #282, I have been testing without this restart mechanism for the EXECUTOR_SERVICE and have not found any downside to doing so

## Goals
> prevent RejectedExecutionException

## Approach
> remove unnecessary restart mechanism

## Test environment
> OSX