### PR TITLE
clean up project related extToServerDefinition when closing a project

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -341,8 +341,10 @@ public class IntellijLanguageClient implements ApplicationComponent, Disposable 
         if (wrapper.getProject() != null) {
             String[] extensions = wrapper.getServerDefinition().ext.split(LanguageServerDefinition.SPLIT_CHAR);
             for (String ext : extensions) {
-                extToLanguageWrapper.remove(new MutablePair<>(ext, FileUtils.pathToUri(
-                        new File(wrapper.getProjectRootPath()).getAbsolutePath())));
+                MutablePair<String, String> extProjectPair = new MutablePair<>(ext, FileUtils.pathToUri(
+                        new File(wrapper.getProjectRootPath()).getAbsolutePath()));
+                extToLanguageWrapper.remove(extProjectPair);
+                extToServerDefinition.remove(extProjectPair);
             }
         } else {
             LOG.error("No attached projects found for wrapper");


### PR DESCRIPTION
## Purpose
> fixes #291 

## Goals
> Ensure that if a project is closed and reopened the lsp still connect properly

## Approach
> clean project related server definition when a project is closed

## Test environment
> OSX