### PR TITLE
prevent NPE of getOpenClose() tristate boolean by converting null to false

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/DefaultRequestManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/DefaultRequestManager.java
@@ -253,7 +253,7 @@ public class DefaultRequestManager implements RequestManager {
     public void didOpen(DidOpenTextDocumentParams params) {
         if (checkStatus()) {
             try {
-                if (textDocumentOptions == null || textDocumentOptions.getOpenClose()) {
+                if (Optional.ofNullable(textDocumentOptions).map(x -> x.getOpenClose()).orElse(false)) {
                     textDocumentService.didOpen(params);
                 }
             } catch (Exception e) {


### PR DESCRIPTION
## Purpose
> fixes #294 

## Goals
> prevent NPE

## Approach
> extra null check in didOpen method so it matches didClose