### PR TITLE
refactor: Drop the type arguments, making it easier to implement

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/extensions/LSPExtensionManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/extensions/LSPExtensionManager.java
@@ -24,7 +24,6 @@ import org.eclipse.lsp4j.services.LanguageServer;
 import org.jetbrains.annotations.NotNull;
 import org.wso2.lsp4intellij.client.ClientContext;
 import org.wso2.lsp4intellij.client.languageserver.ServerOptions;
-import org.wso2.lsp4intellij.client.languageserver.requestmanager.DefaultRequestManager;
 import org.wso2.lsp4intellij.client.languageserver.requestmanager.RequestManager;
 import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
 import org.wso2.lsp4intellij.contributors.icon.LSPDefaultIconProvider;
@@ -50,7 +49,7 @@ public interface LSPExtensionManager {
      * As a starting point you can extend
      * {@link org.wso2.lsp4intellij.client.languageserver.requestmanager.DefaultRequestManager}.
      */
-    <T extends DefaultRequestManager> T getExtendedRequestManagerFor(LanguageServerWrapper wrapper,
+    RequestManager getExtendedRequestManagerFor(LanguageServerWrapper wrapper,
                                                                      LanguageServer server, LanguageClient client,
                                                                      ServerCapabilities serverCapabilities);
 
@@ -65,7 +64,7 @@ public interface LSPExtensionManager {
      * As a starting point you can extend
      * {@link org.wso2.lsp4intellij.editor.EditorEventManager}.
      */
-    <T extends EditorEventManager> T getExtendedEditorEventManagerFor(Editor editor, DocumentListener documentListener,
+    EditorEventManager getExtendedEditorEventManagerFor(Editor editor, DocumentListener documentListener,
                                                                       EditorMouseListenerImpl mouseListener,
                                                                       EditorMouseMotionListenerImpl mouseMotionListener,
                                                                       LSPCaretListenerImpl caretListener,


### PR DESCRIPTION
Maybe I misunderstood the concept. If so, please just close the PR.

---

Judging from the usage of the API, there is no need to use type arguments. The type isn't provided (in form of a class instance) and will be erased anyway during the compilation process.

The API called expecting some interfaces to be implemented, but that can be expressed using plain old Java interfaces.

On the other side, having those generic type arguments make it difficult to implement the interfaces, as the compiler tries to ensure it is possible to cast to `T`, which however is completely unknown.

## Purpose

Make it simpler to implement the interface.
