### PR TITLE
Fix trigger characters and NPE on completion

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
@@ -16,7 +16,11 @@
 package org.wso2.lsp4intellij.contributors.annotator;
 
 import com.intellij.codeInspection.ProblemHighlightType;
-import com.intellij.lang.annotation.*;
+import com.intellij.lang.annotation.Annotation;
+import com.intellij.lang.annotation.AnnotationBuilder;
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.ExternalAnnotator;
+import com.intellij.lang.annotation.HighlightSeverity;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.TextRange;

--- a/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
@@ -16,15 +16,13 @@
 package org.wso2.lsp4intellij.contributors.annotator;
 
 import com.intellij.codeInspection.ProblemHighlightType;
-import com.intellij.lang.annotation.Annotation;
-import com.intellij.lang.annotation.AnnotationHolder;
-import com.intellij.lang.annotation.ExternalAnnotator;
-import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.lang.annotation.*;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.util.TextRange;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiFile;
+import com.intellij.util.SmartList;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticSeverity;
 import org.eclipse.lsp4j.DiagnosticTag;
@@ -133,12 +131,14 @@ public class LSPAnnotator extends ExternalAnnotator<Object, Object> {
             return;
         }
         annotations.forEach(annotation -> {
-            Annotation anon = holder.newAnnotation(annotation.getSeverity(), annotation.getMessage()).createAnnotation();
-
             if (annotation.getQuickFixes() == null || annotation.getQuickFixes().isEmpty()) {
                 return;
             }
-            annotation.getQuickFixes().forEach(quickFixInfo -> anon.registerFix(quickFixInfo.quickFix));
+            AnnotationBuilder builder = holder.newAnnotation(annotation.getSeverity(), annotation.getMessage());
+            for (Annotation.QuickFixInfo quickFixInfo : annotation.getQuickFixes()) {
+                builder = builder.withFix(quickFixInfo.quickFix);
+            }
+            builder.create();
         });
     }
 
@@ -151,9 +151,12 @@ public class LSPAnnotator extends ExternalAnnotator<Object, Object> {
         }
         final TextRange range = new TextRange(start, end);
 
-        return holder.newAnnotation(lspToIntellijAnnotationsMap.get(diagnostic.getSeverity()), diagnostic.getMessage())
+        holder.newAnnotation(lspToIntellijAnnotationsMap.get(diagnostic.getSeverity()), diagnostic.getMessage())
                 .range(range)
-                .createAnnotation();
+                .create();
+
+        SmartList<Annotation> asList = (SmartList<Annotation>) holder;
+        return asList.get(asList.size() - 1);
     }
 
     private void createAnnotations(AnnotationHolder holder, EditorEventManager eventManager) {

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -196,8 +196,12 @@ public class EditorEventManager {
      * @param c The character just typed
      */
     public void characterTyped(char c) {
-        if (signatureTriggers.contains(Character.toString(c))) {
+        String character = Character.toString(c);
+        if (signatureTriggers.contains(character)) {
             signatureHelp();
+        }
+        if (completionTriggers.contains(character)) {
+            completion(DocumentUtils.logicalToLSPPos(editor.getCaretModel().getLogicalPosition(), editor));
         }
     }
 

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -827,8 +827,9 @@ public class EditorEventManager {
         String insertText = item.getInsertText();
         CompletionItemKind kind = item.getKind();
         String label = item.getLabel();
-        TextEdit textEdit = item.getTextEdit().getLeft();
-        InsertReplaceEdit insertReplaceEdit = item.getTextEdit().getRight();
+        Either<TextEdit, InsertReplaceEdit> textEditEither = item.getTextEdit();
+        TextEdit textEdit = (textEditEither != null) ? textEditEither.getLeft() : null;
+        InsertReplaceEdit insertReplaceEdit = (textEditEither != null) ? textEditEither.getRight() : null;
         List<TextEdit> addTextEdits = item.getAdditionalTextEdits();
         String presentableText = StringUtils.isNotEmpty(label) ? label : (insertText != null) ? insertText : "";
         String tailText = (detail != null) ? detail : "";

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -196,12 +196,8 @@ public class EditorEventManager {
      * @param c The character just typed
      */
     public void characterTyped(char c) {
-        String character = Character.toString(c);
-        if (signatureTriggers.contains(character)) {
+        if (signatureTriggers.contains(Character.toString(c))) {
             signatureHelp();
-        }
-        if (completionTriggers.contains(character)) {
-            completion(DocumentUtils.logicalToLSPPos(editor.getCaretModel().getLogicalPosition(), editor));
         }
     }
 

--- a/src/main/java/org/wso2/lsp4intellij/listeners/LSPTypedHandler.java
+++ b/src/main/java/org/wso2/lsp4intellij/listeners/LSPTypedHandler.java
@@ -55,6 +55,7 @@ public class LSPTypedHandler extends TypedHandlerDelegate {
         }
         for (String triggerChar : manager.completionTriggers) {
             if (triggerChar != null && triggerChar.length() == 1 && triggerChar.charAt(0) == charTyped) {
+                AutoPopupController.getInstance(project).scheduleAutoPopup(editor);
                 return Result.STOP;
             }
         }

--- a/src/main/java/org/wso2/lsp4intellij/utils/DocumentUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/DocumentUtils.java
@@ -138,7 +138,10 @@ public class DocumentUtils {
             }
             // lsp and intellij start lines/columns zero-based
             Document doc = editor.getDocument();
-            int line = max(0, Math.min(pos.getLine(), doc.getLineCount() - 1));
+            int line = max(0, Math.min(pos.getLine(), doc.getLineCount()));
+            if (line >= doc.getLineCount()) {
+                return doc.getTextLength();
+            }
             String lineText = doc.getText(DocumentUtil.getLineTextRange(doc, line));
 
             final int positionInLine = max(0, min(lineText.length(), pos.getCharacter()));

--- a/src/main/java/org/wso2/lsp4intellij/utils/DocumentUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/DocumentUtils.java
@@ -138,7 +138,7 @@ public class DocumentUtils {
             }
             // lsp and intellij start lines/columns zero-based
             Document doc = editor.getDocument();
-            int line = max(0, Math.min(pos.getLine(), doc.getLineCount()));
+            int line = max(0, Math.min(pos.getLine(), doc.getLineCount() - 1));
             String lineText = doc.getText(DocumentUtil.getLineTextRange(doc, line));
 
             final int positionInLine = max(0, min(lineText.length(), pos.getCharacter()));
@@ -168,7 +168,7 @@ public class DocumentUtils {
                 return null;
             }
             Document doc = editor.getDocument();
-            int line = max(0, Math.min(pos.getLine(), doc.getLineCount()));
+            int line = max(0, Math.min(pos.getLine(), doc.getLineCount() - 1));
             String lineText = doc.getText(DocumentUtil.getLineTextRange(doc, line));
             final int positionInLine = max(0, min(lineText.length(), pos.getCharacter()));
             int tabs = StringUtil.countChars(lineText, '\t', 0, positionInLine, false);

--- a/src/main/java/org/wso2/lsp4intellij/utils/DocumentUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/DocumentUtils.java
@@ -138,7 +138,7 @@ public class DocumentUtils {
             }
             // lsp and intellij start lines/columns zero-based
             Document doc = editor.getDocument();
-            int line = max(0, Math.min(pos.getLine(), doc.getLineCount() - 1));
+            int line = max(0, Math.min(pos.getLine(), doc.getLineCount()));
             String lineText = doc.getText(DocumentUtil.getLineTextRange(doc, line));
 
             final int positionInLine = max(0, min(lineText.length(), pos.getCharacter()));
@@ -168,7 +168,7 @@ public class DocumentUtils {
                 return null;
             }
             Document doc = editor.getDocument();
-            int line = max(0, Math.min(pos.getLine(), doc.getLineCount() - 1));
+            int line = max(0, Math.min(pos.getLine(), doc.getLineCount()));
             String lineText = doc.getText(DocumentUtil.getLineTextRange(doc, line));
             final int positionInLine = max(0, min(lineText.length(), pos.getCharacter()));
             int tabs = StringUtil.countChars(lineText, '\t', 0, positionInLine, false);


### PR DESCRIPTION
* Fixes an NPE introduced by #274. The new API now returns an `Either` that can be null and we were not checking for it. Looks like other places correctly check for it.
* Fixes #276: Fixes the trigger character handler that broke on #251 (they even added the missing class as a top level import but probably forgot to commit the method call).
* Fixes #300: Removes deprecated calls to `AnnotationBuilder.createAnnotation`. It's not clear to me how to get an `Annotation` object after the API has been deprecated, so I followed another part of the code base: https://github.com/ballerina-platform/lsp4intellij/blob/6ed1ed4adb6a5e6ebe1db0459fc0db015186d529/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java#L1466-L1467
* Fixes a small one-off bug when the LSP sends a range that denotes the entire document.

