### PR TITLE
Allow users to customize the InitializeParams object for the "initialize" method

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/LanguageServerDefinition.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/LanguageServerDefinition.java
@@ -77,6 +77,15 @@ public class LanguageServerDefinition {
     public Object getInitializationOptions(URI uri) {
         return null;
     }
+    
+    /**
+     * Use this method to modify the {@link InitializeParams} that was initialized by this library.
+     * The values assigned to the passed {@link InitializeParams} after this method ends will be the 
+     * ones sent to the LSP server.
+     * @param params the parameters with some prefilled values.
+     */
+    public void customizeInitializeParams(InitializeParams params) {
+    }
 
     @Override
     public String toString() {

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/LanguageServerDefinition.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/serverdefinition/LanguageServerDefinition.java
@@ -18,6 +18,7 @@ package org.wso2.lsp4intellij.client.languageserver.serverdefinition;
 import com.intellij.openapi.diagnostic.Logger;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
+import org.eclipse.lsp4j.InitializeParams;
 import org.wso2.lsp4intellij.client.connection.StreamConnectionProvider;
 
 import java.io.IOException;

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -588,6 +588,7 @@ public class LanguageServerWrapper {
                 new ClientCapabilities(workspaceClientCapabilities, textDocumentClientCapabilities, null));
         initParams.setInitializationOptions(
                 serverDefinition.getInitializationOptions(URI.create(initParams.getRootUri())));
+        serverDefinition.customizeInitializeParams(initParams);
 
         return initParams;
     }


### PR DESCRIPTION
## Purpose
There was no way for users to provide their own values for this object. Now they can by simply overriding this new method.
Feel free to modify this PR directly before merging.

## Goals
Increase flexibility.

## Approach
Usage is as follow:
```kotlin
class MyServerDefinition(ext: String, command: Array<String>) :
    RawCommandServerDefinition(ext, command) {

  override fun customizeInitializeParams(params: InitializeParams) {
    val applicationInfo: ApplicationInfo? =
        ApplicationManager.getApplication().getService(ApplicationInfo::class.java)
    val ideVersion: String? = applicationInfo?.fullVersion
    val ideName = ApplicationNamesInfo.getInstance().fullProductName
    params.clientInfo = ClientInfo(ideName, ideVersion)
  }
}
```