### PR TITLE
Wrap value as a new hash set to avoid the concurrent modification

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
@@ -111,12 +111,7 @@ public class DefaultLanguageClient implements LanguageClient {
     public void publishDiagnostics(PublishDiagnosticsParams publishDiagnosticsParams) {
         String uri = FileUtils.sanitizeURI(publishDiagnosticsParams.getUri());
         List<Diagnostic> diagnostics = publishDiagnosticsParams.getDiagnostics();
-        Set<EditorEventManager> managers = EditorEventManagerBase.managersForUri(uri);
-        if (managers != null) {
-            for (EditorEventManager manager : managers) {
-                manager.diagnostics(diagnostics);
-            }
-        }
+        EditorEventManagerBase.diagnostics(uri, diagnostics);
     }
 
     @Override

--- a/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
@@ -107,12 +107,8 @@ public class DocumentEventManager {
             CharSequence newText = event.getNewFragment();
             int offset = event.getOffset();
             int newTextLength = event.getNewLength();
-            Set<EditorEventManager> managersForUri = EditorEventManagerBase.managersForUri(FileUtils.documentToUri(document));
-            if (managersForUri == null || managersForUri.isEmpty()) {
-                LOG.warn("no manager associated with uri");
-                return;
-            }
-            EditorEventManager editorEventManager = EditorEventManagerBase.managersForUri(FileUtils.documentToUri(document)).iterator().next();
+
+            EditorEventManager editorEventManager = EditorEventManagerBase.forUri(FileUtils.documentToUri(document));
             if (editorEventManager == null) {
                 LOG.warn("no editor associated with document");
                 return;

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
@@ -22,7 +22,11 @@ import org.wso2.lsp4intellij.utils.OSUtils;
 
 import java.awt.KeyboardFocusManager;
 import java.awt.event.KeyEvent;
-import java.util.*;
+import java.util.List;
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Set;
+import java.util.HashSet;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class EditorEventManagerBase {
@@ -160,21 +164,18 @@ public class EditorEventManagerBase {
 
     private static Set<EditorEventManager> getEditorEventManagerCopy(String uri)  {
         HashSet<EditorEventManager> result = new HashSet<>();
-
         synchronized (uriToManagers) {
             Set<EditorEventManager> managers = uriToManagers.get(uri);
             if(managers != null) {
                 result.addAll(managers);
             }
         }
-
-
         return result;
     }
 
     public static void willSave(String uri) {
         EditorEventManager editorManager = forUri(uri);
-        if(editorManager != null){
+        if(editorManager != null) {
             editorManager.willSave();
         }
     }
@@ -200,6 +201,5 @@ public class EditorEventManagerBase {
         if(editorManager != null){
             editorManager.documentSaved();
         }
-
     }
 }

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
@@ -128,8 +128,7 @@ public class EditorEventManagerBase {
 
         String uri = FileUtils.editorToURIString(manager.editor);
         synchronized (uriToManagers) {
-            Set<EditorEventManager> set = uriToManagers.get(uri);
-            set.remove(manager);
+            Set<EditorEventManager> set = getEditorEventManagerCopy(uri);
             if (set.isEmpty()) {
                 uriToManagers.remove(uri);
             }

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
@@ -16,15 +16,13 @@
 package org.wso2.lsp4intellij.editor;
 
 import com.intellij.openapi.editor.Editor;
+import org.eclipse.lsp4j.Diagnostic;
 import org.wso2.lsp4intellij.utils.FileUtils;
 import org.wso2.lsp4intellij.utils.OSUtils;
 
 import java.awt.KeyboardFocusManager;
 import java.awt.event.KeyEvent;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class EditorEventManagerBase {
@@ -82,64 +80,59 @@ public class EditorEventManagerBase {
         EditorEventManagerBase.isKeyPressed = isKeyPressed;
     }
 
-    public static Set<EditorEventManager> managersForUri(String uri) {
-        return uriToManagers.get(uri);
-    }
-
-    /**
-     * WARNING: avoid using this function! It only gives you one editorEventManager, not all and not the one of the current editor.
-     * Only use for operations which are file-level (save, open, close,...) otherwise use {@link #managersForUri(String)} or {@link #forEditor(Editor)}
-     */
-    public static EditorEventManager forUri(String uri) {
-        if (uri == null) {
-            return null;
-        }
-        Set<EditorEventManager> managers = managersForUri(uri);
-        if (managers != null && !managers.isEmpty()) {
-            return (EditorEventManager) managers.toArray()[0];
-        }
-        return null;
-    }
-
-
     private static void prune() {
+        pruneEditorManagerMap();
+        pruneUriManagerMap();
+    }
+
+    private static void pruneUriManagerMap() {
+        synchronized (uriToManagers) {
+            new HashMap<>(uriToManagers).forEach((key, value) -> {
+                new HashSet<>(value).forEach((manager) -> {
+                    if (!manager.wrapper.isActive()) {
+                        uriToManagers.get(key).remove(manager);
+                    }
+                });
+                if (value.isEmpty()) {
+                    uriToManagers.remove(key);
+                }
+            });
+        }
+    }
+
+    private static void pruneEditorManagerMap() {
         new HashMap<>(editorToManager).forEach((key, value) -> {
             if (!value.wrapper.isActive()) {
                 editorToManager.remove(key);
-            }
-        });
-        new HashMap<>(uriToManagers).forEach((key, value) -> {
-            value.forEach((manager) -> {
-                if (!manager.wrapper.isActive()) {
-                    uriToManagers.get(key).remove(manager);
-                }
-            });
-            if (value.isEmpty()) {
-                uriToManagers.remove(key);
             }
         });
     }
 
     public static void registerManager(EditorEventManager manager) {
         String uri = FileUtils.editorToURIString(manager.editor);
-        if (EditorEventManagerBase.uriToManagers.containsKey(uri)) {
-            EditorEventManagerBase.uriToManagers.get(uri).add(manager);
-        } else {
-            HashSet<EditorEventManager> set = new HashSet<>();
-            set.add(manager);
-            EditorEventManagerBase.uriToManagers.put(uri, set);
+        synchronized (uriToManagers) {
+            if (uriToManagers.containsKey(uri)) {
+                uriToManagers.get(uri).add(manager);
+            } else {
+                HashSet<EditorEventManager> set = new HashSet<>();
+                set.add(manager);
+                uriToManagers.put(uri, set);
+            }
         }
-        EditorEventManagerBase.editorToManager.put(manager.editor, manager);
+
+        editorToManager.put(manager.editor, manager);
     }
 
     public static void unregisterManager(EditorEventManager manager) {
-        EditorEventManagerBase.editorToManager.remove(manager.editor);
+        editorToManager.remove(manager.editor);
 
         String uri = FileUtils.editorToURIString(manager.editor);
-        Set<EditorEventManager> set = EditorEventManagerBase.uriToManagers.get(uri);
-        set.remove(manager);
-        if (set.isEmpty()) {
-            EditorEventManagerBase.uriToManagers.remove(uri);
+        synchronized (uriToManagers) {
+            Set<EditorEventManager> set = uriToManagers.get(uri);
+            set.remove(manager);
+            if (set.isEmpty()) {
+                uriToManagers.remove(uri);
+            }
         }
     }
 
@@ -160,4 +153,54 @@ public class EditorEventManagerBase {
         editorToManager.forEach((key, value) -> value.willSave());
     }
 
+    public static void diagnostics(String uri, List<Diagnostic> diagnostics) {
+        getEditorEventManagerCopy(uri).forEach(manager -> {
+            manager.diagnostics(diagnostics);
+        });
+    }
+
+    private static Set<EditorEventManager> getEditorEventManagerCopy(String uri)  {
+        HashSet<EditorEventManager> result = new HashSet<>();
+
+        synchronized (uriToManagers) {
+            Set<EditorEventManager> managers = uriToManagers.get(uri);
+            if(managers != null) {
+                result.addAll(managers);
+            }
+        }
+
+
+        return result;
+    }
+
+    public static void willSave(String uri) {
+        EditorEventManager editorManager = forUri(uri);
+        if(editorManager != null){
+            editorManager.willSave();
+        }
+    }
+
+    public static Set<EditorEventManager> managersForUri(String uri) {
+        return getEditorEventManagerCopy(uri);
+    }
+
+    /**
+     * WARNING: avoid using this function! It only gives you one editorEventManager, not all and not the one of the current editor.
+     * Only use for operations which are file-level (save, open, close,...) otherwise use {@link #managersForUri(String)} or {@link #forEditor(Editor)}
+     */
+    public static EditorEventManager forUri(String uri) {
+        Set<EditorEventManager> managers = managersForUri(uri);
+        if(managers.size() >= 1) {
+            return managers.iterator().next();
+        }
+        return null;
+    }
+
+    public static void documentSaved(String uri) {
+        EditorEventManager editorManager = forUri(uri);
+        if(editorManager != null){
+            editorManager.documentSaved();
+        }
+
+    }
 }

--- a/src/main/java/org/wso2/lsp4intellij/listeners/LSPFileEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/listeners/LSPFileEventManager.java
@@ -54,10 +54,7 @@ class LSPFileEventManager {
      */
     static void willSave(Document doc) {
         String uri = FileUtils.VFSToURI(FileDocumentManager.getInstance().getFile(doc));
-        EditorEventManager manager = EditorEventManagerBase.forUri(uri);
-        if (manager != null) {
-            manager.willSave();
-        }
+        EditorEventManagerBase.willSave(uri);
     }
 
     /**
@@ -83,15 +80,9 @@ class LSPFileEventManager {
         }
 
         ApplicationUtils.invokeAfterPsiEvents(() -> {
-            EditorEventManager manager = EditorEventManagerBase.forUri(uri);
-            if (manager != null) {
-                manager.documentSaved();
-                FileUtils.findProjectsFor(file).forEach(p -> changedConfiguration(uri,
-                    FileUtils.projectToUri(p), FileChangeType.Changed));
-            } else {
-                FileUtils.findProjectsFor(file).forEach(p -> changedConfiguration(uri,
-                    FileUtils.projectToUri(p), FileChangeType.Changed));
-            }
+            EditorEventManagerBase.documentSaved(uri);
+            FileUtils.findProjectsFor(file).forEach(p -> changedConfiguration(uri,
+                FileUtils.projectToUri(p), FileChangeType.Changed));
         });
     }
 


### PR DESCRIPTION
Wrap value as a new hash set to avoid the concurrent modification

Also protected the modifications to the sets stored in the map as there were race conditions involved with the current implementation.

## Purpose
There can be concurrent modification events to the sets stored in as the values in the map, even though the map itself is a ConcurrentHashMap.

Additionally, if multiple threads are operating on the concurrent hash map the values which no longer exist could attempt to be removed.

Adding the synchronization to any access to the map and working on copies of the values prevents both the above issues.

## Goals
Prevent concurrent modification exceptions and NPEs when operating on editor maps.

## Approach
Synchronization on access to the map and operation on copies of the data.
