### PR TITLE
Sanitize the line and column values if they have been reported as negative when converting the to an LSP position

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/utils/DocumentUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/DocumentUtils.java
@@ -117,8 +117,30 @@ public class DocumentUtils {
             int tabs = StringUtil.countChars(lineTextBeforeOffset, '\t');
             int tabSize = getTabSize(editor);
             int column = lineTextBeforeOffset.length() - tabs * (tabSize - 1);
+
+            // Language server positions must be greater than or equal to 0 according to the LSP specification
+            // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position
+            // It is possible for the column (and perhaps line?) to be negative values here
+            // If the value of either is negative, sanitize it to zero
+            line = sanitizeLspPosition(line);
+            column = sanitizeLspPosition(column);
+
             return new Position(line, column);
         });
+    }
+
+    /**
+     * Returns the value if the value is greater than or equal to 0.
+     * If the value is negative returns 0.
+     * 
+     * @param value
+     * @return
+     */
+    private static int sanitizeLspPosition(int value) {
+        if (value < 0) {
+            return 0;
+        }
+        return value;
     }
 
     /**

--- a/src/main/java/org/wso2/lsp4intellij/utils/DocumentUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/DocumentUtils.java
@@ -113,34 +113,9 @@ public class DocumentUtils {
             int line = doc.getLineNumber(offset);
             int lineStart = doc.getLineStartOffset(line);
             String lineTextBeforeOffset = doc.getText(TextRange.create(lineStart, offset));
-
-            int tabs = StringUtil.countChars(lineTextBeforeOffset, '\t');
-            int tabSize = getTabSize(editor);
-            int column = lineTextBeforeOffset.length() - tabs * (tabSize - 1);
-
-            // Language server positions must be greater than or equal to 0 according to the LSP specification
-            // https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#position
-            // It is possible for the column (and perhaps line?) to be negative values here
-            // If the value of either is negative, sanitize it to zero
-            line = sanitizeLspPosition(line);
-            column = sanitizeLspPosition(column);
-
+            int column = lineTextBeforeOffset.length();
             return new Position(line, column);
         });
-    }
-
-    /**
-     * Returns the value if the value is greater than or equal to 0.
-     * If the value is negative returns 0.
-     * 
-     * @param value
-     * @return
-     */
-    private static int sanitizeLspPosition(int value) {
-        if (value < 0) {
-            return 0;
-        }
-        return value;
     }
 
     /**


### PR DESCRIPTION


## Purpose
LSP locations are defined as uint in the specification and the computation for the column values due to the tabs is not correct.  Passing a negative value to an LSP server can cause them to report errors.

## Goals
Prevent passing negative values to LSP servers

## Approach
This particular change prevents the passing of the value, but it may be better to not pass a position at all to the LSP servers instead of a sanitized one.  Additionally, the real fix is probably resolving the computation for the column value but at this time I'm not confident what that may be.  I'll try to take another look at the computation for the column and see if I can determine why it is incorrect in at least some cases.


## Samples
I have a method with the following format in some test code.  Hovering over the word "bad" in the method will cause the incorrect column to be reported.
```
public class Foo {
	public static String giveNull() {
		String bad = null;
		bad += "foo";   // bad
		return bad;
	}
}
```

Here is a screenshot of the data at that time.
![image](https://github.com/ballerina-platform/lsp4intellij/assets/41198264/e657d204-c63a-47e1-b1a0-5c53a52109f5)

