### PR TITLE
Remove deprecated rootUri as it causes NPE

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -591,8 +591,6 @@ public class LanguageServerWrapper {
         textDocumentClientCapabilities.setSynchronization(new SynchronizationCapabilities(true, true, true));
         initParams.setCapabilities(
                 new ClientCapabilities(workspaceClientCapabilities, textDocumentClientCapabilities, null));
-        initParams.setInitializationOptions(
-                serverDefinition.getInitializationOptions(URI.create(initParams.getRootUri())));
 
         // custom initialization options and initialize params provided by users
         initParams.setInitializationOptions(serverDefinition.getInitializationOptions(URI.create(initParams.getWorkspaceFolders().get(0).getUri())));


### PR DESCRIPTION
## Purpose
> Today I pulled master, build lsp4intellij jar and added to my project.
I got yellow icon and my plugin was not working.
After analysis I found that with #312 pull request was changed LanguageServerWrapper#getInitParams().

## Goals
> It would be good that NPE would not be thrown

## Approach
> delete deprecated code



## Release note
> Removed deprecated code related to rootUri

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
>  N/A

## Automation tests
 - I was not able to find any effected unit test

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> It is not thorowing NPE

## Related PRs
> List any other related PRs: #312 

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A