### PR TITLE
Fix NPE when handling Hover Request

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/DefaultRequestManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/DefaultRequestManager.java
@@ -427,7 +427,7 @@ public class DefaultRequestManager implements RequestManager {
             try {
                 return
                         Optional.ofNullable(serverCapabilities.getHoverProvider())
-                                .map(e -> e.getLeft() || e.getRight() != null).orElse(false) ?
+                                .map(e -> e.getRight() != null || e.getLeft()).orElse(false) ?
                                 textDocumentService.hover(params) : null;
 
             } catch (Exception e) {

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/DefaultRequestManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/DefaultRequestManager.java
@@ -427,7 +427,7 @@ public class DefaultRequestManager implements RequestManager {
             try {
                 return
                         Optional.ofNullable(serverCapabilities.getHoverProvider())
-                                .map(e -> e.getRight() != null || e.getLeft()).orElse(false) ?
+                                .map(e -> e.getRight() != null || (e.getLeft() != null && e.getLeft())).orElse(false) ?
                                 textDocumentService.hover(params) : null;
 
             } catch (Exception e) {


### PR DESCRIPTION
## Purpose
In Hover Request the server can respond with either a boolean or HoverOptions. In the current implementation in case when the server responds with HoverOptions the Either.left is `null` and this causes a NullPointerException.

## Goals
The goal is to correctly handle response from the server.

## Approach
A simple reverse of the order of `||` check will prevent the NPE from happening.

## User stories
N/A

## Release note
Fix NPE on Hover Request when the response contains HoverOptions.

## Documentation
N/A

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
N/A
 
## Learning
N/A