### PR TITLE
Removed NullPointer in getInitParams

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -591,8 +591,6 @@ public class LanguageServerWrapper {
         textDocumentClientCapabilities.setSynchronization(new SynchronizationCapabilities(true, true, true));
         initParams.setCapabilities(
                 new ClientCapabilities(workspaceClientCapabilities, textDocumentClientCapabilities, null));
-        initParams.setInitializationOptions(
-                serverDefinition.getInitializationOptions(URI.create(initParams.getRootUri())));
 
         // custom initialization options and initialize params provided by users
         initParams.setInitializationOptions(serverDefinition.getInitializationOptions(URI.create(initParams.getWorkspaceFolders().get(0).getUri())));


### PR DESCRIPTION
## Purpose
This method causes a NullPointerException as the rootUri has been replaced with WorkspaceFolders and this line seems to be duplicated and not needed anymore. With this line, the plugin does not connect to the LSP, as this causes a NPE every time.