### PR TITLE
Set WorkspaceFolder name in InitializationParams

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -572,7 +572,7 @@ public class LanguageServerWrapper {
         workspaceClientCapabilities.setExecuteCommand(new ExecuteCommandCapabilities());
         workspaceClientCapabilities.setWorkspaceEdit(new WorkspaceEditCapabilities());
         workspaceClientCapabilities.setSymbol(new SymbolCapabilities());
-        workspaceClientCapabilities.setWorkspaceFolders(false);
+        workspaceClientCapabilities.setWorkspaceFolders(true);
         workspaceClientCapabilities.setConfiguration(false);
 
         // text document capabilities

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -561,7 +561,7 @@ public class LanguageServerWrapper {
 
     private InitializeParams getInitParams() throws URISyntaxException {
         InitializeParams initParams = new InitializeParams();
-        String projectRootUri = new URI(projectRootPath).toString();
+        String projectRootUri = FileUtils.pathToUri(projectRootPath);
         WorkspaceFolder workspaceFolder = new WorkspaceFolder(projectRootUri, this.project.getName());
         initParams.setWorkspaceFolders(Collections.singletonList(workspaceFolder));
 

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -562,7 +562,8 @@ public class LanguageServerWrapper {
     private InitializeParams getInitParams() throws URISyntaxException {
         InitializeParams initParams = new InitializeParams();
         String projectRootUri = new URI(projectRootPath).toString();
-        initParams.setWorkspaceFolders(Collections.singletonList(new WorkspaceFolder(projectRootUri)));
+        WorkspaceFolder workspaceFolder = new WorkspaceFolder(projectRootUri, this.project.getName());
+        initParams.setWorkspaceFolders(Collections.singletonList(workspaceFolder));
 
         // workspace capabilities
         WorkspaceClientCapabilities workspaceClientCapabilities = new WorkspaceClientCapabilities();


### PR DESCRIPTION
## Purpose
The name field in the WorkspaceFolder entity is not optional in the LSP specification. Therefore, we should set the field to the current project's name. Some LSP implementations rely on this field, as it is not optional. I wonder why there is a constructor in LSP4J without the name...