### PR TITLE
Fix NPE in status widget dispose

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/statusbar/LSPServerStatusWidget.java
+++ b/src/main/java/org/wso2/lsp4intellij/statusbar/LSPServerStatusWidget.java
@@ -20,7 +20,6 @@ import com.intellij.openapi.actionSystem.AnAction;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.actionSystem.DataContext;
 import com.intellij.openapi.actionSystem.DefaultActionGroup;
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.project.DumbAware;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.ui.Messages;
@@ -28,7 +27,6 @@ import com.intellij.openapi.ui.popup.JBPopupFactory;
 import com.intellij.openapi.ui.popup.ListPopup;
 import com.intellij.openapi.wm.StatusBar;
 import com.intellij.openapi.wm.StatusBarWidget;
-import com.intellij.openapi.wm.StatusBarWidgetFactory;
 import com.intellij.openapi.wm.WindowManager;
 import com.intellij.ui.awt.RelativePoint;
 import com.intellij.util.Consumer;
@@ -40,7 +38,6 @@ import org.wso2.lsp4intellij.client.languageserver.ServerStatus;
 import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
 import org.wso2.lsp4intellij.contributors.icon.LSPDefaultIconProvider;
 import org.wso2.lsp4intellij.requests.Timeouts;
-import org.wso2.lsp4intellij.utils.ApplicationUtils;
 import org.wso2.lsp4intellij.utils.GUIUtils;
 
 import java.awt.*;
@@ -105,17 +102,8 @@ public class LSPServerStatusWidget implements StatusBarWidget {
         }
     }
 
-    public void dispose() {
-        WindowManager manager = WindowManager.getInstance();
-        if (manager != null && project != null && !project.isDisposed()) {
-            StatusBar statusBar = manager.getStatusBar(project);
-            if (statusBar != null)
-                ApplicationUtils.invokeLater(() -> {
-                    StatusBarWidgetFactory factory = ServiceManager.getService(StatusBarWidgetFactory.class);
-                    factory.disposeWidget(this);
-                });
-        }
-    }
+    @Override
+    public void dispose() {}
 
     @NotNull
     @Override


### PR DESCRIPTION
## Purpose

Example stack trace on Android Studio Flamingo when closing project:

`java.lang.NullPointerException: Cannot invoke "com.intellij.openapi.wm.StatusBarWidgetFactory.disposeWidget(com.intellij.openapi.wm.StatusBarWidget)" because "factory" is null
	at org.wso2.lsp4intellij.statusbar.LSPServerStatusWidget.lambda$dispose$0(LSPServerStatusWidget.java:115)
	at com.intellij.openapi.application.TransactionGuardImpl.runWithWritingAllowed(TransactionGuardImpl.java:209)
	at com.intellij.openapi.application.TransactionGuardImpl.access$100(TransactionGuardImpl.java:21)
	at com.intellij.openapi.application.TransactionGuardImpl$1.run(TransactionGuardImpl.java:191)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:881)
	at com.intellij.openapi.application.impl.ApplicationImpl$3.run(ApplicationImpl.java:513)
	at com.intellij.openapi.application.impl.FlushQueue.doRun(FlushQueue.java:75)
	at com.intellij.openapi.application.impl.FlushQueue.runNextEvent(FlushQueue.java:118)
	at com.intellij.openapi.application.impl.FlushQueue.flushNow(FlushQueue.java:42)
	at java.desktop/java.awt.event.InvocationEvent.dispatch(InvocationEvent.java:318)
	at java.desktop/java.awt.EventQueue.dispatchEventImpl(EventQueue.java:779)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:730)
	at java.desktop/java.awt.EventQueue$4.run(EventQueue.java:724)
	at java.base/java.security.AccessController.doPrivileged(AccessController.java:399)
	at java.base/java.security.ProtectionDomain$JavaSecurityAccessImpl.doIntersectionPrivilege(ProtectionDomain.java:86)
	at java.desktop/java.awt.EventQueue.dispatchEvent(EventQueue.java:749)
	at com.intellij.ide.IdeEventQueue.defaultDispatchEvent(IdeEventQueue.java:918)
	at com.intellij.ide.IdeEventQueue._dispatchEvent(IdeEventQueue.java:766)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$6(IdeEventQueue.java:450)
	at com.intellij.openapi.progress.impl.CoreProgressManager.computePrioritized(CoreProgressManager.java:791)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$7(IdeEventQueue.java:449)
	at com.intellij.openapi.application.TransactionGuardImpl.performActivity(TransactionGuardImpl.java:105)
	at com.intellij.ide.IdeEventQueue.performActivity(IdeEventQueue.java:624)
	at com.intellij.ide.IdeEventQueue.lambda$dispatchEvent$8(IdeEventQueue.java:447)
	at com.intellij.openapi.application.impl.ApplicationImpl.runIntendedWriteActionOnCurrentThread(ApplicationImpl.java:881)
	at com.intellij.ide.IdeEventQueue.dispatchEvent(IdeEventQueue.java:493)
	at java.desktop/java.awt.EventDispatchThread.pumpOneEventForFilters(EventDispatchThread.java:207)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForFilter(EventDispatchThread.java:128)
	at java.desktop/java.awt.EventDispatchThread.pumpEventsForHierarchy(EventDispatchThread.java:117)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:113)
	at java.desktop/java.awt.EventDispatchThread.pumpEvents(EventDispatchThread.java:105)
	at java.desktop/java.awt.EventDispatchThread.run(EventDispatchThread.java:92)
 `

## Approach

As far as I can tell, manually invoking `disposeWidget()` directly isn't necessary. It's invoked during disposal of the project itself.

To test, close the opened project. With the fix - verify with logging that `LSPServerStatusWidgetFactory.disposeWidget()` is still called.

## Release note

Fix NullPointerException on project close.

## Documentation
N/A

## Test environment
OpenJDK 17, Android Studio Flamingo
