### PR TITLE
fix empty HoverElement when empty markdown value received

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/requests/HoverHandler.java
+++ b/src/main/java/org/wso2/lsp4intellij/requests/HoverHandler.java
@@ -37,7 +37,7 @@ public class HoverHandler {
     private Logger LOG = Logger.getInstance(HoverHandler.class);
 
     /**
-     * Returns the hover string corresponding to an Hover response
+     * Returns the hover string corresponding to a Hover response
      *
      * @param hover The Hover
      * @return The string response
@@ -73,10 +73,13 @@ public class HoverHandler {
                 return "";
             }
         } else if (hoverContents.isRight()) {
+            String markedContent = hoverContents.getRight().getValue();
+            if (markedContent.isEmpty()) {
+                return "";
+            }
             MutableDataSet options = new MutableDataSet();
             Parser parser = Parser.builder(options).build();
             HtmlRenderer renderer = HtmlRenderer.builder(options).build();
-            String markedContent = hoverContents.getRight().getValue();
             return "<html>" + renderer.render(parser.parse(markedContent)) + "</html>";
         } else {
             return "";


### PR DESCRIPTION
This resolves empty hover popups being shown when an empty value is present in the MarkupContent. 

In the EditorEventManager is a check for null or emptyString which is not resolved to true in the current implementation as an empty markdown value resolves to "<html></html>". Therefore, an empty popup is shown.

https://github.com/ballerina-platform/lsp4intellij/blob/72a2879d8279dc86da79200ccb663e97c86163e7/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java#L740-L746