### PR TITLE
Fix go to definition when server returns LocationLink

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -340,13 +340,14 @@ public class EditorEventManager {
             return null;
         }
         try {
-            // for now we only get Location, so we only check the left, but in future we might need to support
-            // right as well which will return LocationLink
             Either<List<? extends Location>, List<? extends LocationLink>> definition =
                     request.get(getTimeout(DEFINITION), TimeUnit.MILLISECONDS);
             wrapper.notifySuccess(Timeouts.DEFINITION);
             if (definition.isLeft() && !definition.getLeft().isEmpty()) {
                 return definition.getLeft().get(0);
+            } else if (definition.isRight() && !definition.getRight().isEmpty()) {
+                var def = definition.getRight().get(0);
+                return new Location(def.getTargetUri(), def.getTargetRange());
             }
         } catch (TimeoutException e) {
             LOG.warn(e);


### PR DESCRIPTION
## Purpose
"Go to definition" completely breaks down when using LSP4IntelliJ for connecting to the [Zig Language Server](https://github.com/zigtools/zls).
The source of this issue was that ZLS returns a `LocationLink` instead of a Location in the reply to the `definition` call, and this causes lsp4intellij to "spazz out", and open dozens of unrelated editors.

## Goals
Implement a basic way for interpreting `LocationLink` without affecting too much of the codebase.

## Approach
`LocationLink` contains all of the information necessary to construct a `Location` object, so I just added a trivial conversion to the `EditorEventManager.requestDefinition` method.

## User stories
I have personally experienced this problem while developing a Zig language plugin for intellij using this library.
Once the fix was implemented in a local fork, go to definition started working normally again.

## Release note
Added basic compatibility with `LocationLink` responses for definition lookups.