### PR TITLE
Ignore URIs that do not start with 'file:'

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/utils/FileUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/FileUtils.java
@@ -150,11 +150,15 @@ public class FileUtils {
 
     public static VirtualFile virtualFileFromURI(String uri) {
         try {
-            return LocalFileSystem.getInstance().findFileByIoFile(new File(new URI(sanitizeURI(uri))));
+            URI sanitizedUri = new URI(sanitizeURI(uri));
+            if (sanitizedUri.getScheme().startsWith(URI_FILE_BEGIN)) {
+                return LocalFileSystem.getInstance().findFileByIoFile(new File(sanitizedUri));
+            }
+            LOG.debug(String.format("URI %s is not a file", uri));
         } catch (URISyntaxException e) {
             LOG.warn(e);
-            return null;
         }
+        return null;
     }
 
     /**
@@ -249,12 +253,7 @@ public class FileUtils {
      * @return The virtual file
      */
     public static VirtualFile URIToVFS(String uri) {
-        try {
-            return LocalFileSystem.getInstance().findFileByIoFile(new File(new URI(sanitizeURI(uri))));
-        } catch (URISyntaxException e) {
-            LOG.warn(e);
-            return null;
-        }
+        return virtualFileFromURI(uri);
     }
 
     /**


### PR DESCRIPTION
## Purpose
Ignore URIs that do not start with `file://`

Using URIs that have other schemes could lead to `IllegalArgumentException`

**Sample stack-trace:** 

> java.lang.IllegalArgumentException: URI scheme is not "file"
at java.base/java.io.File.<init>(File.java:423)
at org.wso2.lsp4intellij.utils.FileUtils.virtualFileFromURI(FileUtils.java:153)
at org.wso2.lsp4intellij.utils.FileUtils.getAllOpenedEditorsForUri(FileUtils.java:87)
at org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper.connect(LanguageServerWrapper.java:748)

The above exception happens when opening a de-complied source file that have scheme `JRT://`