### PR TITLE
Fix: Hover font should use editor font settings

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/requests/HoverHandler.java
+++ b/src/main/java/org/wso2/lsp4intellij/requests/HoverHandler.java
@@ -26,6 +26,7 @@ import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.validation.NonNull;
 
+import java.awt.Font;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -46,6 +47,7 @@ public class HoverHandler {
         if (hover == null || hover.getContents() == null) {
             return "";
         }
+        Font font = UIUtil.getLabelFont();
         Either<List<Either<String, MarkedString>>, MarkupContent> hoverContents = hover.getContents();
         if (hoverContents.isLeft()) {
             List<Either<String, MarkedString>> contents = hoverContents.getLeft();
@@ -68,7 +70,7 @@ public class HoverHandler {
                         result.add(renderer.render(parser.parse(string)));
                     }
                 }
-                return "<html><style>p {margin: 0; color: " + (UIUtil.isUnderDarcula() ? "rgb(187,187,187)" : "black") + ";</style>" + String.join("\n\n", result) + "</html>";
+                return "<html>" + UIUtil.getCssFontDeclaration(font) + String.join("\n\n", result) + "</html>";
             } else {
                 return "";
             }
@@ -80,7 +82,7 @@ public class HoverHandler {
             MutableDataSet options = new MutableDataSet();
             Parser parser = Parser.builder(options).build();
             HtmlRenderer renderer = HtmlRenderer.builder(options).build();
-            return "<html>" + renderer.render(parser.parse(markedContent)) + "</html>";
+            return "<html>" + UIUtil.getCssFontDeclaration(font) + renderer.render(parser.parse(markedContent)) + "</html>";
         } else {
             return "";
         }


### PR DESCRIPTION
## Purpose
The Hover feature uses a fixed font size that is not configurable, and doesn't scale with the editor font size.
![Screenshot 2023-09-20 at 3 44 07 PM](https://github.com/ballerina-platform/lsp4intellij/assets/5856969/6d6ea72c-9aae-4332-b559-1d235a302a5b)

## Goals
Make the Hover display text which appears similar to the rest of the UI, such as completions and action menus.

## Approach
I used the `UiUtil` class (already used here to get the dark/light mode) to instead get the label font and generate corresponding HTML styles. Below is a demonstration of Darcula and IntelliJ Light themes:

![Screenshot 2023-09-20 at 3 45 42 PM](https://github.com/ballerina-platform/lsp4intellij/assets/5856969/badeb27f-6785-4648-905c-2b2b92afff14)
![Screenshot 2023-09-20 at 3 58 36 PM](https://github.com/ballerina-platform/lsp4intellij/assets/5856969/39f5bbf7-04cd-4f25-9dd2-fcedb8cb5a2c)

This is an example with `.AppleSystemUIFont` size 18. I can't figure out what the original font or size was prior to this change, as it wasn't configurable.

## User stories
A user that needs to change their font or increase their font size for accessibility will see their font size reflected in the hover similar to how it appears in the rest of the IntelliJ UI.

## Release note
Documentation hover now uses the global editor font style

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Test environment
OpenJDK 17, arm64 mac Ventura