### PR TITLE
Fix: Request code actions immediately after diagnostics arrive

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
@@ -107,16 +107,7 @@ public class LSPAnnotator extends ExternalAnnotator<Object, Object> {
             // TODO annotations are applied to a file / document not to an editor. so store them by file and not by editor..
             EditorEventManager eventManager = EditorEventManagerBase.forUri(uri);
 
-            if (eventManager.isCodeActionSyncRequired()) {
-                try {
-                    updateAnnotations(holder, eventManager);
-                } catch (ConcurrentModificationException e) {
-                    // Todo - Add proper fix to handle concurrent modifications gracefully.
-                    LOG.warn("Error occurred when updating LSP diagnostics due to concurrent modifications.", e);
-                } catch (Throwable t) {
-                    LOG.warn("Error occurred when updating LSP diagnostics.", t);
-                }
-            } else if (eventManager.isDiagnosticSyncRequired()) {
+            if (eventManager.isDiagnosticSyncRequired()) {
                 try {
                     createAnnotations(holder, eventManager);
                 } catch (ConcurrentModificationException e) {
@@ -124,6 +115,16 @@ public class LSPAnnotator extends ExternalAnnotator<Object, Object> {
                     LOG.warn("Error occurred when updating LSP code actions due to concurrent modifications.", e);
                 } catch (Throwable t) {
                     LOG.warn("Error occurred when updating LSP code actions.", t);
+                }
+                eventManager.requestAndShowCodeActions();
+            } else if (eventManager.isCodeActionSyncRequired()) {
+                try {
+                    updateAnnotations(holder, eventManager);
+                } catch (ConcurrentModificationException e) {
+                    // Todo - Add proper fix to handle concurrent modifications gracefully.
+                    LOG.warn("Error occurred when updating LSP diagnostics due to concurrent modifications.", e);
+                } catch (Throwable t) {
+                    LOG.warn("Error occurred when updating LSP diagnostics.", t);
                 }
             }
         }

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -1475,7 +1475,8 @@ public class EditorEventManager {
             });
             // If code actions are updated, forcefully triggers the inspection tool.
             if (codeActionSyncRequired) {
-                updateErrorAnnotations();
+                // double-delay the update to ensure that the code analyzer finishes.
+                invokeLater(this::updateErrorAnnotations);
             }
         });
     }


### PR DESCRIPTION
## Purpose
Currently in order to compute code actions, the user must move their cursor within a diagnostic, and wait for the cursor debounce before selecting the code action.

## Goals
Code actions should be computed immediately after obtaining diagnostics, without waiting for the user to move the cursor within the diagnostic.

## Approach
I added a call to EditorEventManager::requestAndShowCodeActions() inside the isDiagnosticsSyncRequired() branch in LSPAnnotator. This should mean that each time after the diagnostics are updated, the code actions valid for the current cursor will be checked.

This operation has some delay (as it is making a request to the language server) so the results must be processed on a subsequent LSPAnnotator run. I had some issues with what appeared to be the DaemonCodeAnalyzer still running at the time restart(PsiFile) was called, so no subsequent LSPAnnotator run would be triggered. I inserted an additional invokeLater to fix this, which appears to work deterministically, but looks a bit silly and probably isn't the right solution. If you have an alternative to this, please let me know.

Finally, I had issues where the LSPAnnotator would "loop" and continuously call updateAnnotations even if there were new annotations that had to be created. I fixed this by inverting the precedence of the createAnnotations and updateAnnotations, so that if both new diagnostics and new actions are available, the new diagnostics will be applied preferentially.

## User stories
Before:
A user types something incorrectly, and the LSP server issues a diagnostic. They must move their caret at least once before the LSP server issues a code action. They can then select the code action to fix the mistake.

After:
A user types something incorrectly, and the LSP server issues a diagnostic and code action to fix the character their caret is on. They can immediately select the code-action to fix their mistake.

## Release note
Code actions are now shown as soon as they are available, instead of only after moving the caret.

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no


## Test environment
openjdk 17, arm64 mac Ventura
