### PR TITLE
Fix: Code action annotations lose range

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/annotator/LSPAnnotator.java
@@ -139,7 +139,12 @@ public class LSPAnnotator extends ExternalAnnotator<Object, Object> {
                 return;
             }
             AnnotationBuilder builder = holder.newAnnotation(annotation.getSeverity(), annotation.getMessage());
+            boolean range = true;
             for (Annotation.QuickFixInfo quickFixInfo : annotation.getQuickFixes()) {
+                if (range) {
+                    builder = builder.range(quickFixInfo.textRange);
+                    range = false;
+                }
                 builder = builder.withFix(quickFixInfo.quickFix);
             }
             builder.create();


### PR DESCRIPTION
## Purpose
When issuing a diagnostic with a particular range, annotations are only displayed for that range.
When issuing a code action for a diagnostic with a particular range, the annotation is applied to the whole document.

## Goals
A code action should only cause the range specified by the action to be underlined with an error.

## Approach

Use the `AnnotationBuilder::range` parameter to forward the `QuickFixInfo.textRange` from the actions to the newly created annotation. In order to avoid an IllegalStateException from setting the range twice, use a variable to only set it once.

## User stories
A user which has a server which provides code actions will have not have their whole document highlighted as an error each time a code action is usable.

## Release note
Fix bug where code actions highlighted entire file as an error

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no


## Test environment
openjdk 17, arm64 mac Ventura