### PR TITLE
Fixing closing/reopening files

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -159,7 +159,7 @@ public class IntellijLanguageClient implements ApplicationComponent, Disposable 
     }
 
     /**
-     * @return All registered LSP protocol extension managers.
+     * @return All registered LSP protocol extension managers for the given file extension.
      */
     public static LSPExtensionManager getExtensionManagerFor(String fileExt) {
         if (extToExtManager.containsKey(fileExt)) {

--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -148,7 +148,7 @@ public class IntellijLanguageClient implements ApplicationComponent, Disposable 
     /**
      * @return All instantiated ServerWrappers
      */
-    public static Set<LanguageServerWrapper> getAllServerWrappersFor(String projectUri) {
+    public static @NotNull Set<LanguageServerWrapper> getAllServerWrappersFor(String projectUri) {
         Set<LanguageServerWrapper> allWrappers = new HashSet<>();
         extToLanguageWrapper.forEach((stringStringPair, languageServerWrapper) -> {
             if (FileUtils.projectToUri(languageServerWrapper.getProject()).equals(projectUri)) {
@@ -161,7 +161,7 @@ public class IntellijLanguageClient implements ApplicationComponent, Disposable 
     /**
      * @return All registered LSP protocol extension managers for the given file extension.
      */
-    public static LSPExtensionManager getExtensionManagerFor(String fileExt) {
+    public static @Nullable LSPExtensionManager getExtensionManagerFor(String fileExt) {
         if (extToExtManager.containsKey(fileExt)) {
             return extToExtManager.get(fileExt);
         }

--- a/src/main/java/org/wso2/lsp4intellij/actions/LSPQuickDocAction.java
+++ b/src/main/java/org/wso2/lsp4intellij/actions/LSPQuickDocAction.java
@@ -35,7 +35,7 @@ import org.wso2.lsp4intellij.editor.EditorEventManagerBase;
  * Action overriding QuickDoc (CTRL+Q)
  */
 class LSPQuickDocAction extends ShowQuickDocInfoAction implements DumbAware {
-    private Logger LOG = Logger.getInstance(LSPQuickDocAction.class);
+    private final Logger LOG = Logger.getInstance(LSPQuickDocAction.class);
 
     @Override
     public void actionPerformed(AnActionEvent e) {

--- a/src/main/java/org/wso2/lsp4intellij/actions/LSPReformatAction.java
+++ b/src/main/java/org/wso2/lsp4intellij/actions/LSPReformatAction.java
@@ -33,7 +33,7 @@ import org.wso2.lsp4intellij.requests.ReformatHandler;
  * Fallback to the default action if the language is already supported or not supported by any language server
  */
 public class LSPReformatAction extends ReformatCodeAction implements DumbAware {
-    private Logger LOG = Logger.getInstance(LSPReformatAction.class);
+    private final Logger LOG = Logger.getInstance(LSPReformatAction.class);
 
     @Override
     public void actionPerformed(AnActionEvent e) {

--- a/src/main/java/org/wso2/lsp4intellij/actions/LSPShowReformatDialogAction.java
+++ b/src/main/java/org/wso2/lsp4intellij/actions/LSPShowReformatDialogAction.java
@@ -40,7 +40,7 @@ import org.wso2.lsp4intellij.editor.EditorEventManagerBase;
  */
 public class LSPShowReformatDialogAction extends ShowReformatFileDialog implements DumbAware {
     private String HELP_ID = "editing.codeReformatting";
-    private Logger LOG = Logger.getInstance(LSPShowReformatDialogAction.class);
+    private final Logger LOG = Logger.getInstance(LSPShowReformatDialogAction.class);
 
     @Override
     public void actionPerformed(AnActionEvent e) {

--- a/src/main/java/org/wso2/lsp4intellij/client/connection/ProcessStreamConnectionProvider.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/connection/ProcessStreamConnectionProvider.java
@@ -35,7 +35,7 @@ import java.util.Objects;
  */
 public class ProcessStreamConnectionProvider implements StreamConnectionProvider {
 
-    private Logger LOG = Logger.getInstance(ProcessStreamConnectionProvider.class);
+    private final Logger LOG = Logger.getInstance(ProcessStreamConnectionProvider.class);
 
     @Nullable
     private ProcessBuilder builder;
@@ -56,13 +56,13 @@ public class ProcessStreamConnectionProvider implements StreamConnectionProvider
 
     public void start() throws IOException {
         if ((workingDir == null || commands == null || commands.isEmpty() || commands.contains(null)) && builder == null) {
-            throw new IOException("Unable to start language server: " + this.toString());
+            throw new IOException("Unable to start language server: " + this);
         }
         ProcessBuilder builder = createProcessBuilder();
         LOG.info("Starting server process with commands " + commands + " and workingDir " + workingDir);
         process = builder.start();
         if (!process.isAlive()) {
-            throw new IOException("Unable to start language server: " + this.toString());
+            throw new IOException("Unable to start language server: " + this);
         } else {
             LOG.info("Server process started " + process);
         }

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -84,7 +84,6 @@ import org.wso2.lsp4intellij.client.languageserver.ServerStatus;
 import org.wso2.lsp4intellij.client.languageserver.requestmanager.DefaultRequestManager;
 import org.wso2.lsp4intellij.client.languageserver.requestmanager.RequestManager;
 import org.wso2.lsp4intellij.client.languageserver.serverdefinition.LanguageServerDefinition;
-import org.wso2.lsp4intellij.editor.DocumentEventManager;
 import org.wso2.lsp4intellij.editor.EditorEventManager;
 import org.wso2.lsp4intellij.editor.EditorEventManagerBase;
 import org.wso2.lsp4intellij.extensions.LSPExtensionManager;
@@ -472,7 +471,6 @@ public class LanguageServerWrapper {
 
             // sadly this whole editor closing stuff runs asynchronously, so we cannot be sure the state is really clean here...
             // therefore clear the mapping from here as it should be empty by now.
-            DocumentEventManager.clearState();
             uriToEditorManagers.clear();
             urisUnderLspControl.clear();
             launcherFuture = null;

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -458,7 +458,7 @@ public class LanguageServerWrapper {
         } catch (Exception e) {
             // most likely closed externally.
             notifyFailure(Timeouts.SHUTDOWN);
-            LOG.warn("exception occured while trying to shut down", e);
+            LOG.warn("exception occurred while trying to shut down", e);
         } finally {
             if (launcherFuture != null) {
                 launcherFuture.cancel(true);

--- a/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
@@ -33,7 +33,6 @@ import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
-import org.wso2.lsp4intellij.client.languageserver.requestmanager.RequestManager;
 import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
 import org.wso2.lsp4intellij.utils.ApplicationUtils;
 import org.wso2.lsp4intellij.utils.DocumentUtils;
@@ -52,7 +51,7 @@ public class DocumentEventManager {
     private final LanguageServerWrapper wrapper;
     private final TextDocumentIdentifier identifier;
     private int version = -1;
-    protected Logger LOG = Logger.getInstance(EditorEventManager.class);
+    protected Logger LOG = Logger.getInstance(DocumentEventManager.class);
     private static final Map<String, DocumentEventManager> uriToDocumentEventManager = new HashMap<>();
 
     private final Set<Document> openDocuments = new HashSet<>();

--- a/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
@@ -39,9 +39,7 @@ import org.wso2.lsp4intellij.utils.DocumentUtils;
 import org.wso2.lsp4intellij.utils.FileUtils;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 
 public class DocumentEventManager {
@@ -52,7 +50,6 @@ public class DocumentEventManager {
     private final TextDocumentIdentifier identifier;
     private int version = -1;
     protected Logger LOG = Logger.getInstance(DocumentEventManager.class);
-    private static final Map<String, DocumentEventManager> uriToDocumentEventManager = new HashMap<>();
 
     private final Set<Document> openDocuments = new HashSet<>();
 
@@ -62,22 +59,6 @@ public class DocumentEventManager {
         this.syncKind = syncKind;
         this.wrapper = wrapper;
         this.identifier = new TextDocumentIdentifier(FileUtils.documentToUri(document));
-    }
-
-    public static void clearState() {
-        uriToDocumentEventManager.clear();
-    }
-
-    public static DocumentEventManager getOrCreateDocumentManager(Document document, DocumentListener listener, TextDocumentSyncKind syncKind, LanguageServerWrapper wrapper) {
-        DocumentEventManager manager = uriToDocumentEventManager.get(FileUtils.documentToUri(document));
-        if (manager != null) {
-            return manager;
-        }
-
-        manager = new DocumentEventManager(document, listener, syncKind, wrapper);
-
-        uriToDocumentEventManager.put(FileUtils.documentToUri(document), manager);
-        return manager;
     }
 
     public void removeListeners() {

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -1333,7 +1333,7 @@ public class EditorEventManager {
         }
     }
 
-    // Tries to go to definition / show usages based on the element which is
+    /** Tries to go to definition / show usages based on the element which is */
     private void trySourceNavigationAndHover(EditorMouseEvent e) {
         if (editor.isDisposed()) {
             return;

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -172,7 +172,7 @@ public class EditorEventManager {
 
         this.currentHint = null;
 
-        this.documentEventManager = DocumentEventManager.getOrCreateDocumentManager(editor.getDocument(), documentListener, syncKind, wrapper);
+        this.documentEventManager = new DocumentEventManager(editor.getDocument(), documentListener, syncKind, wrapper);
     }
 
     @SuppressWarnings("unused")

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
@@ -132,9 +132,12 @@ public class EditorEventManagerBase {
 
         String uri = FileUtils.editorToURIString(manager.editor);
         synchronized (uriToManagers) {
-            Set<EditorEventManager> set = getEditorEventManagerCopy(uri);
-            if (set.isEmpty()) {
-                uriToManagers.remove(uri);
+            Set<EditorEventManager> managers = uriToManagers.get(uri);
+            if (managers != null) {
+                managers.remove(manager);
+                if (managers.isEmpty()) {
+                    uriToManagers.remove(uri);
+                }
             }
         }
     }

--- a/src/main/java/org/wso2/lsp4intellij/listeners/LSPEditorListener.java
+++ b/src/main/java/org/wso2/lsp4intellij/listeners/LSPEditorListener.java
@@ -15,7 +15,6 @@
  */
 package org.wso2.lsp4intellij.listeners;
 
-import com.intellij.openapi.components.ServiceManager;
 import com.intellij.openapi.editor.EditorKind;
 import com.intellij.openapi.editor.event.EditorFactoryEvent;
 import com.intellij.openapi.editor.event.EditorFactoryListener;

--- a/src/main/java/org/wso2/lsp4intellij/listeners/LSPEditorListener.java
+++ b/src/main/java/org/wso2/lsp4intellij/listeners/LSPEditorListener.java
@@ -15,12 +15,12 @@
  */
 package org.wso2.lsp4intellij.listeners;
 
-        import com.intellij.openapi.components.ServiceManager;
-        import com.intellij.openapi.editor.EditorKind;
-        import com.intellij.openapi.editor.event.EditorFactoryEvent;
-        import com.intellij.openapi.editor.event.EditorFactoryListener;
-        import org.jetbrains.annotations.NotNull;
-        import org.wso2.lsp4intellij.IntellijLanguageClient;
+import com.intellij.openapi.components.ServiceManager;
+import com.intellij.openapi.editor.EditorKind;
+import com.intellij.openapi.editor.event.EditorFactoryEvent;
+import com.intellij.openapi.editor.event.EditorFactoryListener;
+import org.jetbrains.annotations.NotNull;
+import org.wso2.lsp4intellij.IntellijLanguageClient;
 
 public class LSPEditorListener implements EditorFactoryListener {
 

--- a/src/main/java/org/wso2/lsp4intellij/listeners/LSPFileEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/listeners/LSPFileEventManager.java
@@ -180,15 +180,7 @@ class LSPFileEventManager {
                     FileUtils.findProjectsFor(file).forEach(p -> {
                         // Detaches old file from the wrappers.
                         Set<LanguageServerWrapper> wrappers = IntellijLanguageClient.getAllServerWrappersFor(FileUtils.projectToUri(p));
-                        wrappers.forEach(wrapper -> {
-                            // make these calls first since the disconnect might stop the LS client if its last file.
-                            wrapper.getRequestManager().didChangeWatchedFiles(
-                                getDidChangeWatchedFilesParams(oldFileUri, FileChangeType.Deleted));
-                            wrapper.getRequestManager().didChangeWatchedFiles(
-                                getDidChangeWatchedFilesParams(newFileUri, FileChangeType.Created));
-
-                            wrapper.disconnect(oldFileUri, FileUtils.projectToUri(p));
-                        });
+                        wrappers.forEach(wrapper -> wrapper.disconnect(oldFileUri, FileUtils.projectToUri(p)));
                         if (!newFileUri.equals(oldFileUri)) {
                             // Re-open file to so that the new editor will be connected to the language server.
                             FileEditorManager fileEditorManager = FileEditorManager.getInstance(p);

--- a/src/main/java/org/wso2/lsp4intellij/listeners/LSPFileEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/listeners/LSPFileEventManager.java
@@ -115,9 +115,7 @@ class LSPFileEventManager {
                 FileUtils.findProjectsFor(file).forEach(p -> {
                     // Detaches old file from the wrappers.
                     Set<LanguageServerWrapper> wrappers = IntellijLanguageClient.getAllServerWrappersFor(FileUtils.projectToUri(p));
-                    if (wrappers != null) {
-                        wrappers.forEach(wrapper -> wrapper.disconnect(oldFileUri, FileUtils.projectToUri(p)));
-                    }
+                    wrappers.forEach(wrapper -> wrapper.disconnect(oldFileUri, FileUtils.projectToUri(p)));
                     // Re-open file to so that the new editor will be connected to the language server.
                     FileEditorManager fileEditorManager = FileEditorManager.getInstance(p);
                     ApplicationUtils.invokeLater(() -> {
@@ -182,17 +180,15 @@ class LSPFileEventManager {
                     FileUtils.findProjectsFor(file).forEach(p -> {
                         // Detaches old file from the wrappers.
                         Set<LanguageServerWrapper> wrappers = IntellijLanguageClient.getAllServerWrappersFor(FileUtils.projectToUri(p));
-                        if (wrappers != null) {
-                            wrappers.forEach(wrapper -> {
-                                // make these calls first since the disconnect might stop the LS client if its last file.
-                                wrapper.getRequestManager().didChangeWatchedFiles(
-                                    getDidChangeWatchedFilesParams(oldFileUri, FileChangeType.Deleted));
-                                wrapper.getRequestManager().didChangeWatchedFiles(
-                                    getDidChangeWatchedFilesParams(newFileUri, FileChangeType.Created));
+                        wrappers.forEach(wrapper -> {
+                            // make these calls first since the disconnect might stop the LS client if its last file.
+                            wrapper.getRequestManager().didChangeWatchedFiles(
+                                getDidChangeWatchedFilesParams(oldFileUri, FileChangeType.Deleted));
+                            wrapper.getRequestManager().didChangeWatchedFiles(
+                                getDidChangeWatchedFilesParams(newFileUri, FileChangeType.Created));
 
-                                wrapper.disconnect(oldFileUri, FileUtils.projectToUri(p));
-                            });
-                        }
+                            wrapper.disconnect(oldFileUri, FileUtils.projectToUri(p));
+                        });
                         if (!newFileUri.equals(oldFileUri)) {
                             // Re-open file to so that the new editor will be connected to the language server.
                             FileEditorManager fileEditorManager = FileEditorManager.getInstance(p);
@@ -231,9 +227,6 @@ class LSPFileEventManager {
         ApplicationUtils.pool(() -> {
             DidChangeWatchedFilesParams params = getDidChangeWatchedFilesParams(uri, typ);
             Set<LanguageServerWrapper> wrappers = IntellijLanguageClient.getAllServerWrappersFor(projectUri);
-            if (wrappers == null) {
-                return;
-            }
             for (LanguageServerWrapper wrapper : wrappers) {
                 if (wrapper.getRequestManager() != null
                         && wrapper.getStatus() == ServerStatus.INITIALIZED) {

--- a/src/main/java/org/wso2/lsp4intellij/listeners/LSPFileEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/listeners/LSPFileEventManager.java
@@ -173,10 +173,12 @@ class LSPFileEventManager {
             Set<LanguageServerWrapper> wrappers = IntellijLanguageClient.getAllServerWrappersFor(FileUtils.projectToUri(p));
             wrappers.forEach(wrapper -> wrapper.disconnect(oldFileUri, FileUtils.projectToUri(p)));
             if (!newFileUri.equals(oldFileUri)) {
+                // TODO: abort if the file was not opened prior to this operation
                 // Re-open file to so that the new editor will be connected to the language server.
                 FileEditorManager fileEditorManager = FileEditorManager.getInstance(p);
                 ApplicationUtils.invokeLater(() -> {
                     fileEditorManager.closeFile(file);
+                    // TODO: only focus if the file was previously already focused
                     fileEditorManager.openFile(file, true);
                 });
             }

--- a/src/main/java/org/wso2/lsp4intellij/listeners/LSPListener.java
+++ b/src/main/java/org/wso2/lsp4intellij/listeners/LSPListener.java
@@ -19,7 +19,7 @@ import com.intellij.openapi.diagnostic.Logger;
 import org.wso2.lsp4intellij.editor.EditorEventManager;
 
 public class LSPListener {
-    private Logger LOG = Logger.getInstance(LSPListener.class);
+    private final Logger LOG = Logger.getInstance(LSPListener.class);
     protected EditorEventManager manager = null;
     protected boolean enabled = true;
 

--- a/src/main/java/org/wso2/lsp4intellij/utils/FileUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/FileUtils.java
@@ -349,8 +349,10 @@ public class FileUtils {
                 isFileContentSupported(editor);
     }
 
-    // Always returns true unless the user has registered filtering to validate file content via LS protocol extension
-    // manager implementation.
+    /**
+     * Always returns true unless the user has registered filtering to validate file content via LS protocol extension
+     * manager implementation.
+     */
     private static boolean isFileContentSupported(Editor editor) {
         return computableReadAction(() -> {
             if (editor.getProject() == null) {


### PR DESCRIPTION
# Many things were causing issues related to closing and reopening files (fixes #344)

Core changes are (I could be wrong on any of this, so please be careful when you review this... you can follow my investigation and train of thought in #344):
* (https://github.com/ballerina-platform/lsp4intellij/pull/345/commits/9b2b0557c93dbdb8cbe2b7a6b09925286a44d663) `LSPFileEventManager#fileRenamed` was sending duplicate `didChangeWatchedFiles` notifications.
* (https://github.com/ballerina-platform/lsp4intellij/pull/345/commits/bc9c5ea31c2b0735f3a3620d64b72e58198d24a5) `EditorEventManagerBase#unregisterManager` was not appropriately cleaning up the `Set<EditorEventManager>`.
  * This was causing `DocumentEventManager#documentClosed` to not hit the appropriate code path because `EditorEventManagerBase.managersForUri` was not appropriately maintained. (In turns causing the `documentOpened` to also be broken.)
* (https://github.com/ballerina-platform/lsp4intellij/pull/345/commits/34b29ee729c85d59b972313f5480c305785228d8) `EditorEventManager`'s constructor was erroneously trying to reuse a previous `DocumentEventManager`.
  * This was causing calls to `documentChanged` to be aborted because the associated `editor` had been disposed.
  * This means that `DocumentEventManager`'s `uriToDocumentEventManager ` was not useful anymore, thus all the related code was removed.

This PR also fixes a bunch of misc stuff I encountered while digging around:
* unused import
* indent
* `final` properties
* wrong logger
* implicit calls
* typo
* JavaDoc
* duplicated logic
* nullabilities and associated null-checks

***The original issue (#344) also points out many things which would still be worth investigating. I highly encourage the maintainers to closely read through it.***