### PR TITLE
Add IDE notifications for LSP progress update messages

### DIFF
--- a/resources/plugin.xml.example
+++ b/resources/plugin.xml.example
@@ -25,6 +25,9 @@ see also jetbrains documentation: https://plugins.jetbrains.com/docs/intellij/pl
         <!-- for displaying notifications by lsp -->
         <notificationGroup id="lsp" displayType="STICKY_BALLOON"/>
 
+        <!-- for displaying progress notifications by lsp in the Event Log -->
+        <notificationGroup id="LSPProgressNotification" displayType="NONE" />
+
         <!-- for displaying the statusbar icon -->
         <statusBarWidgetFactory implementation="org.wso2.lsp4intellij.statusbar.LSPServerStatusWidgetFactory"
                                 id="org.wso2.lsp4intellij.statusbar.LSPServerStatusWidgetFactory"

--- a/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
@@ -334,7 +334,7 @@ public class DefaultLanguageClient implements LanguageClient {
             }
         }
         if (extension != null) {
-            title = " (" + extension + " extension" + ") " + title;
+            title = " [" + extension + " extension" + "] " + title;
         }
         Notification notification =
                 notificationGroup.createNotification(title, message, NotificationType.INFORMATION, null);

--- a/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
@@ -293,7 +293,6 @@ public class DefaultLanguageClient implements LanguageClient {
 
     @Override
     public CompletableFuture<Void> createProgress(WorkDoneProgressCreateParams params) {
-        // give a unique identifier if the token is null
         String token;
         if (params.getToken().getLeft() != null) {
             token = params.getToken().getLeft();

--- a/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
@@ -47,6 +47,7 @@ import org.eclipse.lsp4j.WorkDoneProgressNotification;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.jetbrains.annotations.NotNull;
+import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
 import org.wso2.lsp4intellij.editor.EditorEventManagerBase;
 import org.wso2.lsp4intellij.requests.WorkspaceEditHandler;
 import org.wso2.lsp4intellij.utils.ApplicationUtils;
@@ -335,7 +336,14 @@ public class DefaultLanguageClient implements LanguageClient {
                 title = progressNotificationItems.get(token).getFirst();
             }
         }
-        String extension = ((ServerWrapperBaseClientContext) context).getWrapper().serverDefinition.ext;
+        String extension = null;
+        if (context instanceof ServerWrapperBaseClientContext) {
+            ServerWrapperBaseClientContext serverContext = (ServerWrapperBaseClientContext) context;
+            LanguageServerWrapper wrapper = serverContext.getWrapper();
+            if (wrapper != null && wrapper.serverDefinition != null) {
+                extension = wrapper.serverDefinition.ext;
+            }
+        }
         if (extension != null) {
             title = " [" + extension + " extension" + "] " + title;
         }

--- a/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
@@ -294,11 +294,13 @@ public class DefaultLanguageClient implements LanguageClient {
     @Override
     public CompletableFuture<Void> createProgress(WorkDoneProgressCreateParams params) {
         // give a unique identifier if the token is null
-        String token = String.valueOf(params.hashCode());
+        String token;
         if (params.getToken().getLeft() != null) {
             token = params.getToken().getLeft();
         } else if (params.getToken().getRight() != null){
             token = params.getToken().getRight().toString();
+        } else {
+            return null;
         }
         Tuple2<String, String> progressNotificationItem = new Tuple2<>("LSP Progress Notification", "");
         progressNotificationItems.put(token, progressNotificationItem);
@@ -310,11 +312,13 @@ public class DefaultLanguageClient implements LanguageClient {
         NotificationGroup notificationGroup =
                 NotificationGroupManager.getInstance().getNotificationGroup("LSPProgressNotification");
 
-        String token = String.valueOf(params.hashCode());
+        String token;
         if (params.getToken().getLeft() != null) {
             token = params.getToken().getLeft();
         } else if (params.getToken().getRight() != null){
             token = params.getToken().getRight().toString();
+        } else {
+            return;
         }
         String title = progressNotificationItems.get(token).getFirst();
         String message = progressNotificationItems.get(token).getSecond();

--- a/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
@@ -61,7 +61,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
 
-import javax.swing.*;
+import javax.swing.Icon;
 
 public class DefaultLanguageClient implements LanguageClient {
 

--- a/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
@@ -20,26 +20,48 @@ import com.intellij.notification.NotificationAction;
 import com.intellij.notification.NotificationGroup;
 import com.intellij.notification.NotificationGroupManager;
 import com.intellij.notification.NotificationType;
+import com.intellij.notification.Notifications;
 import com.intellij.openapi.actionSystem.AnActionEvent;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.ui.Messages;
 import com.intellij.util.ui.UIUtil;
-import org.eclipse.lsp4j.*;
+import groovy.lang.Tuple2;
+import org.eclipse.lsp4j.ApplyWorkspaceEditParams;
+import org.eclipse.lsp4j.ApplyWorkspaceEditResponse;
+import org.eclipse.lsp4j.ConfigurationParams;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.MessageActionItem;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.MessageType;
+import org.eclipse.lsp4j.ProgressParams;
+import org.eclipse.lsp4j.PublishDiagnosticsParams;
+import org.eclipse.lsp4j.RegistrationParams;
+import org.eclipse.lsp4j.ShowMessageRequestParams;
+import org.eclipse.lsp4j.Unregistration;
+import org.eclipse.lsp4j.UnregistrationParams;
+import org.eclipse.lsp4j.WorkDoneProgressBegin;
+import org.eclipse.lsp4j.WorkDoneProgressCreateParams;
+import org.eclipse.lsp4j.WorkDoneProgressEnd;
+import org.eclipse.lsp4j.WorkDoneProgressNotification;
+import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.jetbrains.annotations.NotNull;
-import org.wso2.lsp4intellij.editor.EditorEventManager;
 import org.wso2.lsp4intellij.editor.EditorEventManagerBase;
 import org.wso2.lsp4intellij.requests.WorkspaceEditHandler;
 import org.wso2.lsp4intellij.utils.ApplicationUtils;
 import org.wso2.lsp4intellij.utils.FileUtils;
 
-import javax.swing.*;
-import java.util.*;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.FutureTask;
+
+import javax.swing.*;
 
 public class DefaultLanguageClient implements LanguageClient {
 
@@ -52,9 +74,12 @@ public class DefaultLanguageClient implements LanguageClient {
     @NotNull
     private final ClientContext context;
     protected boolean isModal = false;
+    private final String extension;
+    private final HashMap<String, Tuple2<String, String>> progressNotificationItems = new HashMap<>();
 
-    public DefaultLanguageClient(@NotNull ClientContext context) {
+    public DefaultLanguageClient(@NotNull ClientContext context, String extension) {
         this.context = context;
+        this.extension = extension;
     }
 
     @Override
@@ -264,5 +289,55 @@ public class DefaultLanguageClient implements LanguageClient {
     @NotNull
     protected final ClientContext getContext() {
         return context;
+    }
+
+    @Override
+    public CompletableFuture<Void> createProgress(WorkDoneProgressCreateParams params) {
+        String token;
+        if (params.getToken().getLeft() != null) {
+            token = params.getToken().getLeft();
+        } else {
+            token = params.getToken().getRight().toString();
+        }
+        Tuple2<String, String> progressNotificationItem = new Tuple2<>("LSP Progress Notification", "");
+        progressNotificationItems.put(token, progressNotificationItem);
+        return null;
+    }
+
+    @Override
+    public void notifyProgress(ProgressParams params) {
+        NotificationGroup notificationGroup =
+                NotificationGroupManager.getInstance().getNotificationGroup("LSPProgressNotification");
+
+        String token;
+        if (params.getToken().getLeft() != null) {
+            token = params.getToken().getLeft();
+        } else {
+            token = params.getToken().getRight().toString();
+        }
+        String title = progressNotificationItems.get(token).getFirst();
+        String message = progressNotificationItems.get(token).getSecond();
+        WorkDoneProgressNotification progressNotification = params.getValue().getLeft();
+        if (progressNotification instanceof WorkDoneProgressBegin) {
+            title = ((WorkDoneProgressBegin) progressNotification).getTitle();
+            message = ((WorkDoneProgressBegin) progressNotification).getMessage();
+            Tuple2<String, String> progressNotificationItem = new Tuple2<>(title, message);
+            if (progressNotificationItems.containsKey(token)) {
+                progressNotificationItems.replace(token, progressNotificationItem);
+            } else {
+                progressNotificationItems.put(token, progressNotificationItem);
+            }
+        } else if (progressNotification instanceof WorkDoneProgressEnd) {
+            message = ((WorkDoneProgressEnd) progressNotification).getMessage();
+            if (progressNotificationItems.containsKey(token)) {
+                title = progressNotificationItems.get(token).getFirst();
+            }
+        }
+        if (extension != null) {
+            title = " (" + extension + " extension" + ") " + title;
+        }
+        Notification notification =
+                notificationGroup.createNotification(title, message, NotificationType.INFORMATION, null);
+        Notifications.Bus.notify(notification);
     }
 }

--- a/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
@@ -74,12 +74,10 @@ public class DefaultLanguageClient implements LanguageClient {
     @NotNull
     private final ClientContext context;
     protected boolean isModal = false;
-    private final String extension;
     private final HashMap<String, Tuple2<String, String>> progressNotificationItems = new HashMap<>();
 
-    public DefaultLanguageClient(@NotNull ClientContext context, String extension) {
+    public DefaultLanguageClient(@NotNull ClientContext context) {
         this.context = context;
-        this.extension = extension;
     }
 
     @Override
@@ -337,6 +335,7 @@ public class DefaultLanguageClient implements LanguageClient {
                 title = progressNotificationItems.get(token).getFirst();
             }
         }
+        String extension = ((ServerWrapperBaseClientContext) context).getWrapper().serverDefinition.ext;
         if (extension != null) {
             title = " [" + extension + " extension" + "] " + title;
         }

--- a/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/DefaultLanguageClient.java
@@ -293,10 +293,11 @@ public class DefaultLanguageClient implements LanguageClient {
 
     @Override
     public CompletableFuture<Void> createProgress(WorkDoneProgressCreateParams params) {
-        String token;
+        // give a unique identifier if the token is null
+        String token = String.valueOf(params.hashCode());
         if (params.getToken().getLeft() != null) {
             token = params.getToken().getLeft();
-        } else {
+        } else if (params.getToken().getRight() != null){
             token = params.getToken().getRight().toString();
         }
         Tuple2<String, String> progressNotificationItem = new Tuple2<>("LSP Progress Notification", "");
@@ -309,10 +310,10 @@ public class DefaultLanguageClient implements LanguageClient {
         NotificationGroup notificationGroup =
                 NotificationGroupManager.getInstance().getNotificationGroup("LSPProgressNotification");
 
-        String token;
+        String token = String.valueOf(params.hashCode());
         if (params.getToken().getLeft() != null) {
             token = params.getToken().getLeft();
-        } else {
+        } else if (params.getToken().getRight() != null){
             token = params.getToken().getRight().toString();
         }
         String title = progressNotificationItems.get(token).getFirst();

--- a/src/main/java/org/wso2/lsp4intellij/client/ServerWrapperBaseClientContext.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/ServerWrapperBaseClientContext.java
@@ -46,4 +46,8 @@ public class ServerWrapperBaseClientContext implements ClientContext {
     public RequestManager getRequestManager() {
         return wrapper.getRequestManager();
     }
+
+    public LanguageServerWrapper getWrapper() {
+        return wrapper;
+    }
 }

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -527,7 +527,7 @@ public class LanguageServerWrapper {
                     languageServer = launcher.getRemoteProxy();
                     launcherFuture = launcher.startListening();
                 } else {
-                    client = new DefaultLanguageClient(new ServerWrapperBaseClientContext(this));
+                    client = new DefaultLanguageClient(new ServerWrapperBaseClientContext(this), serverDefinition.ext);
                     Launcher<LanguageServer> launcher = Launcher
                             .createLauncher(client, LanguageServer.class, inputStream, outputStream, executorService,
                                     messageHandler);

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -527,7 +527,7 @@ public class LanguageServerWrapper {
                     languageServer = launcher.getRemoteProxy();
                     launcherFuture = launcher.startListening();
                 } else {
-                    client = new DefaultLanguageClient(new ServerWrapperBaseClientContext(this), serverDefinition.ext);
+                    client = new DefaultLanguageClient(new ServerWrapperBaseClientContext(this));
                     Launcher<LanguageServer> launcher = Launcher
                             .createLauncher(client, LanguageServer.class, inputStream, outputStream, executorService,
                                     messageHandler);


### PR DESCRIPTION
## Purpose
Adds editor event log tab notifications for LSP messages that display progress update information. Display notifications for start and end of a work done progress. This also fixes the issue https://github.com/ballerina-platform/lsp4intellij/issues/347 that happens due to not supporting LSP progress indication messages.

## Approach
```createProgress(WorkDoneProgressCreateParams params)```: This method is triggered upon receiving a _**window/workDoneProgress/create**_ request from the language server. It extracts the progress token from the request parameters, which can be either a String or a numeric value. This token uniquely identifies the progress report session. The method then initializes a progress notification item with a default title and an empty message, associating it with the token in a map for later reference. This setup prepares the IDE to handle upcoming progress notifications associated with this token.

```notifyProgress(ProgressParams params)```: Activated by the _**$/progress**_ notification from the language server, this method manages the display of progress notifications within the IDE. It first retrieves the progress token from the notification parameters, similar to createProgress. Using this token, it fetches the corresponding progress notification item from the map. The method then updates the title and message based on the type of progress notification received (e.g., WorkDoneProgressBegin, WorkDoneProgressEnd). 

Notification will be associated with the extension name provided when initializing the language client.

## Samples

![image](https://github.com/ballerina-platform/lsp4intellij/assets/110608712/b9c99c42-262c-4342-948a-53dae227b565)

![image](https://github.com/ballerina-platform/lsp4intellij/assets/110608712/e60e0ae1-5332-4503-a820-603a4f492ccc)