### PR TITLE
Suppress the IllegalArgumentException thrown when creating a new annotation

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -1459,17 +1459,19 @@ public class EditorEventManager {
                         int endOffset = editor.getDocument().getLineEndOffset(line);
                         TextRange range = new TextRange(startOffset, endOffset);
 
-                        this.anonHolder
-                                .newAnnotation(HighlightSeverity.INFORMATION, codeAction.getTitle())
-                                .range(range)
-                                .withFix(new LSPCodeActionFix(FileUtils.editorToURIString(editor), codeAction))
-                                .create();
+                        try {
+                            this.anonHolder
+                                    .newAnnotation(HighlightSeverity.INFORMATION, codeAction.getTitle())
+                                    .range(range)
+                                    .withFix(new LSPCodeActionFix(FileUtils.editorToURIString(editor), codeAction))
+                                    .create();
 
-                        SmartList<Annotation> asList = (SmartList<Annotation>) this.anonHolder;
-                        this.annotations.add(asList.get(asList.size() - 1));
-
-
-                        diagnosticSyncRequired = true;
+                            SmartList<Annotation> asList = (SmartList<Annotation>) this.anonHolder;
+                            this.annotations.add(asList.get(asList.size() - 1));
+                            diagnosticSyncRequired = true;
+                        } catch (IllegalArgumentException e) {
+                            LOG.warn("Error when creating a new annotation");
+                        }
                     }
                 }
             });


### PR DESCRIPTION
## Purpose
Triggering code actions without a diagnostic context currently results in an ```IllegalArgumentException```. This fix will ensure that the corresponding IDE error message is suppressed.

Related to https://github.com/ballerina-platform/lsp4intellij/issues/278

## Approach
Gracefully handle ```IllegalArgumentException``` within a try-catch block. This error will be thrown when creating a new annotation object to display the relevant code action.