### PR TITLE
Fix error diagnostics and code actions display issues

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/MessageHandler.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/MessageHandler.java
@@ -50,7 +50,6 @@ class MessageHandler implements Function<MessageConsumer, MessageConsumer> {
                 }
             }
         };
-
     }
 
     private void handleMessage(Message message) {

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/MessageHandler.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/MessageHandler.java
@@ -15,6 +15,7 @@
  */
 package org.wso2.lsp4intellij.client.languageserver.wrapper;
 
+import com.esotericsoftware.minlog.Log;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.jsonrpc.MessageConsumer;
 import org.eclipse.lsp4j.jsonrpc.messages.Message;
@@ -42,7 +43,11 @@ class MessageHandler implements Function<MessageConsumer, MessageConsumer> {
         return message -> {
             if(isRunning.getAsBoolean()) {
                 handleMessage(message);
-                messageConsumer.consume(message);
+                try {
+                    messageConsumer.consume(message);
+                } catch (Exception e) {
+                    Log.warn("Error while consuming message", e);
+                }
             }
         };
 

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -1526,8 +1526,8 @@ public class EditorEventManager {
         return silentAnnotations;
     }
 
-    public void refreshAnnotations(){
-        if (!annotationsRefreshed){
+    public void refreshAnnotations() {
+        if (!annotationsRefreshed) {
             updateErrorAnnotations();
             annotationsRefreshed = true;
         }

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -1475,12 +1475,6 @@ public class EditorEventManager {
                         int startOffset = editor.getDocument().getLineStartOffset(line);
                         int endOffset = editor.getDocument().getLineEndOffset(line);
                         TextRange range = new TextRange(startOffset, endOffset);
-                        Tuple3<HighlightSeverity, TextRange, LSPCodeActionFix> triple =
-                                new Tuple3<>(
-                                        HighlightSeverity.INFORMATION,
-                                        range,
-                                        new LSPCodeActionFix(FileUtils.editorToURIString(editor), codeAction)
-                                );
                         boolean found = silentAnnotations.stream()
                                 .anyMatch(silentAnnotation ->
                                         silentAnnotation.getSecond().getStartOffset() == startOffset &&
@@ -1488,7 +1482,13 @@ public class EditorEventManager {
                                         silentAnnotation.getThird().getText().equals(codeAction.getTitle())
                                  );
                         if (!found) {
-                            silentAnnotations.add(triple);
+                            Tuple3<HighlightSeverity, TextRange, LSPCodeActionFix> sAnnotation =
+                                    new Tuple3<>(
+                                            HighlightSeverity.INFORMATION,
+                                            range,
+                                            new LSPCodeActionFix(FileUtils.editorToURIString(editor), codeAction)
+                                    );
+                            silentAnnotations.add(sAnnotation);
                         }
                         codeActionSyncRequired = true;
                     }

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -1481,19 +1481,16 @@ public class EditorEventManager {
                                         range,
                                         new LSPCodeActionFix(FileUtils.editorToURIString(editor), codeAction)
                                 );
-                        boolean found = false;
-                        for (Tuple3<HighlightSeverity, TextRange, LSPCodeActionFix> silentAnnotation : silentAnnotations) {
-                            if (silentAnnotation.getSecond().getStartOffset() == startOffset
-                                    && silentAnnotation.getSecond().getEndOffset() == endOffset
-                                    && silentAnnotation.getThird().getText().equals(codeAction.getTitle())) {
-                                found = true;
-                                break;
-                            }
-                        }
+                        boolean found = silentAnnotations.stream()
+                                .anyMatch(silentAnnotation ->
+                                        silentAnnotation.getSecond().getStartOffset() == startOffset &&
+                                        silentAnnotation.getSecond().getEndOffset() == endOffset &&
+                                        silentAnnotation.getThird().getText().equals(codeAction.getTitle())
+                                 );
                         if (!found) {
                             silentAnnotations.add(triple);
-                            codeActionSyncRequired = true;
                         }
+                        codeActionSyncRequired = true;
                     }
                 }
             });
@@ -1529,6 +1526,7 @@ public class EditorEventManager {
     public void refreshAnnotations() {
         if (!annotationsRefreshed) {
             updateErrorAnnotations();
+            silentAnnotations.clear();
             annotationsRefreshed = true;
         }
     }

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -52,6 +52,7 @@ import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.ui.Hint;
 import com.intellij.util.SmartList;
+import groovy.lang.Tuple3;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.lsp4j.*;
 import org.eclipse.lsp4j.jsonrpc.JsonRpcException;
@@ -141,6 +142,10 @@ public class EditorEventManager {
     private static final long CTRL_THRESH = EditorSettingsExternalizable.getInstance().getTooltipsDelay() * 1000000;
 
     public static final String SNIPPET_PLACEHOLDER_REGEX = "(\\$\\{\\d+:?([^{^}]*)}|\\$\\d+)";
+
+    private List<Tuple3<HighlightSeverity,TextRange,LSPCodeActionFix>> silentAnnotations = new ArrayList<>();
+
+    private boolean annotationsRefreshed = false;
 
     //Todo - Revisit arguments order and add remaining listeners
     public EditorEventManager(Editor editor, DocumentListener documentListener, EditorMouseListener mouseListener,
@@ -1426,27 +1431,41 @@ public class EditorEventManager {
                 }
                 if (element.isLeft()) {
                     Command command = element.getLeft();
-                    annotations.forEach(annotation -> {
+                    Annotation annotWithCodeAction = null;
+                    for (Annotation annotation : annotations) {
                         int start = annotation.getStartOffset();
                         int end = annotation.getEndOffset();
                         if (start <= caretPos && end >= caretPos) {
                             annotation.registerFix(new LSPCommandFix(FileUtils.editorToURIString(editor), command),
                                     new TextRange(start, end));
                             codeActionSyncRequired = true;
+                            annotWithCodeAction = annotation;
+                            break;
                         }
-                    });
+                    }
+                    if (annotWithCodeAction != null) {
+                        annotations.remove(annotWithCodeAction);
+                        annotations.add(0, annotWithCodeAction);
+                    }
                 } else if (element.isRight()) {
                     CodeAction codeAction = element.getRight();
                     List<Diagnostic> diagnosticContext = codeAction.getDiagnostics();
-                    annotations.forEach(annotation -> {
+                    Annotation annotWithCodeAction = null;
+                    for (Annotation annotation : annotations) {
                         int start = annotation.getStartOffset();
                         int end = annotation.getEndOffset();
                         if (start <= caretPos && end >= caretPos) {
                             annotation.registerFix(new LSPCodeActionFix(FileUtils.editorToURIString(editor),
                                     codeAction), new TextRange(start, end));
                             codeActionSyncRequired = true;
+                            annotWithCodeAction = annotation;
+                            break;
                         }
-                    });
+                    }
+                    if (annotWithCodeAction != null) {
+                        annotations.remove(annotWithCodeAction);
+                        annotations.add(0, annotWithCodeAction);
+                    }
 
                     // If the code actions does not have a diagnostics context, creates an intention action for
                     // the current line.
@@ -1456,19 +1475,24 @@ public class EditorEventManager {
                         int startOffset = editor.getDocument().getLineStartOffset(line);
                         int endOffset = editor.getDocument().getLineEndOffset(line);
                         TextRange range = new TextRange(startOffset, endOffset);
-
-                        try {
-                            this.anonHolder
-                                    .newAnnotation(HighlightSeverity.INFORMATION, codeAction.getTitle())
-                                    .range(range)
-                                    .withFix(new LSPCodeActionFix(FileUtils.editorToURIString(editor), codeAction))
-                                    .create();
-
-                            SmartList<Annotation> asList = (SmartList<Annotation>) this.anonHolder;
-                            this.annotations.add(asList.get(asList.size() - 1));
-                            diagnosticSyncRequired = true;
-                        } catch (IllegalArgumentException e) {
-                            LOG.warn("Error when creating a new annotation");
+                        Tuple3<HighlightSeverity, TextRange, LSPCodeActionFix> triple =
+                                new Tuple3<>(
+                                        HighlightSeverity.INFORMATION,
+                                        range,
+                                        new LSPCodeActionFix(FileUtils.editorToURIString(editor), codeAction)
+                                );
+                        boolean found = false;
+                        for (Tuple3<HighlightSeverity, TextRange, LSPCodeActionFix> silentAnnotation : silentAnnotations) {
+                            if (silentAnnotation.getSecond().getStartOffset() == startOffset
+                                    && silentAnnotation.getSecond().getEndOffset() == endOffset
+                                    && silentAnnotation.getThird().getText().equals(codeAction.getTitle())) {
+                                found = true;
+                                break;
+                            }
+                        }
+                        if (!found) {
+                            silentAnnotations.add(triple);
+                            codeActionSyncRequired = true;
                         }
                     }
                 }
@@ -1478,6 +1502,7 @@ public class EditorEventManager {
                 // double-delay the update to ensure that the code analyzer finishes.
                 invokeLater(this::updateErrorAnnotations);
             }
+            annotationsRefreshed = false;
         });
     }
 
@@ -1495,6 +1520,17 @@ public class EditorEventManager {
             DaemonCodeAnalyzer.getInstance(project).restart(file);
             return null;
         });
+    }
+
+    public List<Tuple3<HighlightSeverity,TextRange,LSPCodeActionFix>> getSilentAnnotations() {
+        return silentAnnotations;
+    }
+
+    public void refreshAnnotations(){
+        if (!annotationsRefreshed){
+            updateErrorAnnotations();
+            annotationsRefreshed = true;
+        }
     }
 
     private static class LSPTextEdit implements Comparable<LSPTextEdit> {


### PR DESCRIPTION
## Purpose
These fixes will ensure that error diagnostics are displayed upon opening an editor and address the issue of error diagnostics disappearing. Additionally, code actions will be displayed as expected, and error highlights will remain visible when a code action is triggered. Error diagnostics with identical start and end offsets will also be displayed correctly.
Related to https://github.com/ballerina-platform/lsp4intellij/issues/353, https://github.com/ballerina-platform/lsp4intellij/issues/265

## Approach
1. Added an extra condition in the `didOpen(DidOpenTextDocumentParams params)` function to check if the language server supports file syncing and to trigger the language server's didOpen command. This ensures that error diagnostics are visible upon opening an editor.
2. Removed a condition in the `public Object collectInformation(@NotNull PsiFile file, @NotNull Editor editor, boolean hasErrors)` method, enabling error diagnostics to consistently display when the corresponding functions in the LSPAnnotator class are invoked.
3. Changed an else if condition to an else condition in `public void apply(@NotNull PsiFile file, Object annotationResult, @NotNull AnnotationHolder holder)` to ensure annotation updates are triggered, preventing annotations from disappearing under certain circumstances.
4. Modified `private void updateAnnotations(AnnotationHolder holder, EditorEventManager eventManager)` to process and display all annotations in the editor, rather than only those with code action fixes.
5. Updated the condition in `protected Annotation createAnnotation(Editor editor, AnnotationHolder holder, Diagnostic diagnostic)` to properly display annotations with identical start and end offsets.
6. `eventManager.refreshAnnotations()` is invoked to show the code actions balloon when the caret moves to a position with available code actions. Initially, no code actions are displayed since they must be fetched from the Language Server. Once available, this function is called again to display the annotations and, consequently, the code actions balloon, using a `private boolean annotationsRefreshed` state variable to prevent function looping.
7. For code actions lacking diagnostic context for each editor, a new list `private List<Tuple3<HighlightSeverity,TextRange,LSPCodeActionFix>> silentAnnotations = new ArrayList<>()` stores them separately. This is because the `newAnnotation` function cannot be called within `requestAndShowCodeActions()`, and these code actions are displayed as silent annotations via `private void updateSilentAnnotations(AnnotationHolder holder, EditorEventManager eventManager)`. Silent annotations do not show a hover popup but will display the code actions balloon.
8. Implemented minor optimizations to prevent duplicate code actions in the list above and to prioritize displaying code actions before error highlights.

## Samples

**Displaying error diagnostics with identical start and end offset**

![image](https://github.com/ballerina-platform/lsp4intellij/assets/110608712/72e396e4-2564-40f9-902e-55ae457bdfb1)

**Error diagnostics do not disappear**

https://github.com/ballerina-platform/lsp4intellij/assets/110608712/57ddb601-720a-4c95-b3d5-4a8fa1f19777


**Code actions displaying properly**

https://github.com/ballerina-platform/lsp4intellij/assets/110608712/00f448a3-cfc1-4328-80f6-0e77e784f666



