### PR TITLE
Add code action resolving

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/DefaultRequestManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/DefaultRequestManager.java
@@ -593,6 +593,20 @@ public class DefaultRequestManager implements RequestManager {
     }
 
     @Override
+    public CompletableFuture<CodeAction> resolveCodeAction(CodeAction unresolved) {
+        if (checkStatus()) {
+            try {
+                return checkCodeActionResolveProvider(serverCapabilities.getCodeActionProvider())
+                        ? textDocumentService.resolveCodeAction(unresolved) : null;
+            } catch (Exception e) {
+                crashed(e);
+                return null;
+            }
+        }
+        return null;
+    }
+
+    @Override
     public CompletableFuture<List<? extends CodeLens>> codeLens(CodeLensParams params) {
         if (checkStatus()) {
             try {
@@ -719,5 +733,10 @@ public class DefaultRequestManager implements RequestManager {
     private boolean checkCodeActionProvider(Either<Boolean, CodeActionOptions> provider) {
         return provider != null && ((provider.isLeft() && provider.getLeft()) || (provider.isRight()
                 && provider.getRight() != null));
+    }
+
+    private boolean checkCodeActionResolveProvider(Either<Boolean, CodeActionOptions> provider) {
+        return provider != null && provider.isRight() && provider.getRight() != null
+                && provider.getRight().getResolveProvider();
     }
 }

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/RequestManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/RequestManager.java
@@ -151,6 +151,9 @@ public interface RequestManager extends LanguageClient, TextDocumentService, Wor
     CompletableFuture<List<Either<Command, CodeAction>>> codeAction(CodeActionParams params);
 
     @Override
+    CompletableFuture<CodeAction> resolveCodeAction(CodeAction unresolved);
+
+    @Override
     CompletableFuture<List<? extends CodeLens>> codeLens(CodeLensParams params);
 
     @Override

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -37,6 +37,7 @@ import org.eclipse.lsp4j.ClientInfo;
 import org.eclipse.lsp4j.CodeActionCapabilities;
 import org.eclipse.lsp4j.CodeActionKindCapabilities;
 import org.eclipse.lsp4j.CodeActionLiteralSupportCapabilities;
+import org.eclipse.lsp4j.CodeActionResolveSupportCapabilities;
 import org.eclipse.lsp4j.CompletionCapabilities;
 import org.eclipse.lsp4j.CompletionItemCapabilities;
 import org.eclipse.lsp4j.DefinitionCapabilities;
@@ -163,6 +164,8 @@ public class LanguageServerWrapper {
     private static final Map<Project, LanguageServerWrapper> projectToLanguageServerWrapper = new ConcurrentHashMap<>();
     private static final Logger LOG = Logger.getInstance(LanguageServerWrapper.class);
     private static final CloudNotifier notifier = new CloudNotifier("Language Server Protocol client");
+
+    private static final List<String> codeActionResolveProperties = new ArrayList<>(List.of("edit"));
 
     public LanguageServerWrapper(@NotNull LanguageServerDefinition serverDefinition, @NotNull Project project) {
         this(serverDefinition, project, null);
@@ -583,6 +586,7 @@ public class LanguageServerWrapper {
         TextDocumentClientCapabilities textDocumentClientCapabilities = new TextDocumentClientCapabilities();
         textDocumentClientCapabilities.setCodeAction(new CodeActionCapabilities());
         textDocumentClientCapabilities.getCodeAction().setCodeActionLiteralSupport(new CodeActionLiteralSupportCapabilities(new CodeActionKindCapabilities()));
+        textDocumentClientCapabilities.getCodeAction().setResolveSupport(new CodeActionResolveSupportCapabilities(codeActionResolveProperties));
         textDocumentClientCapabilities.setCompletion(new CompletionCapabilities(new CompletionItemCapabilities(true)));
         textDocumentClientCapabilities.setDefinition(new DefinitionCapabilities());
         textDocumentClientCapabilities.setDocumentHighlight(new DocumentHighlightCapabilities());


### PR DESCRIPTION
## Purpose
This PR adds the code actions resolving feature in LSP to the library. Related to https://github.com/ballerina-platform/lsp4intellij/issues/362

## Approach
If a returned code action has no workspace edits, we call the code actions resolving endpoint with the initial code action and it will return a new code action with the complete workspace edit.