### PR TITLE
Fix LanguageServerWrapper memory leak on file URI drift

### DIFF
--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -201,8 +201,18 @@ public class LanguageServerWrapper {
      * @return The wrapper for the given editor, or None
      */
     public static LanguageServerWrapper forEditor(Editor editor) {
-        return uriToLanguageServerWrapper.get(
+        LanguageServerWrapper wrapper = uriToLanguageServerWrapper.get(
                 new ImmutablePair<>(editorToURIString(editor), editorToProjectFolderUri(editor)));
+        if (wrapper != null) {
+            return wrapper;
+        }
+        // Fallback for when the editor's URI drifted (file moved/renamed) after it was connected.
+        for (LanguageServerWrapper candidate : uriToLanguageServerWrapper.values()) {
+            if (candidate.connectedEditors.contains(editor)) {
+                return candidate;
+            }
+        }
+        return null;
     }
 
     public static LanguageServerWrapper forProject(Project project) {
@@ -737,7 +747,8 @@ public class LanguageServerWrapper {
         connectedEditors.remove(editor);
         if (manager != null) {
             manager.removeListeners();
-            String uri = editorToURIString(editor);
+            // URI captured at connect time — the editor's current URI may have drifted since.
+            String uri = manager.getIdentifier().getUri();
             Set<EditorEventManager> set = uriToEditorManagers.get(uri);
             if (set != null) {
                 set.remove(manager);


### PR DESCRIPTION
## Purpose
Fixes https://github.com/ballerina-platform/lsp4intellij/issues/279


## Goals
> Describe the solutions that this feature/fix will introduce to resolve the problems described above

## Approach
> Describe how you are implementing the solutions. Include an animated GIF or screenshot if the change affects the UI (email documentation@wso2.com to review all UI text). Include a link to a Markdown file or Google doc if the feature write-up is too long to paste here.

## User stories
> Summary of user stories addressed by this change>

## Release note
> Brief description of the new feature or bug fix as it will appear in the release notes

## Documentation
> Link(s) to product documentation that addresses the changes of this PR. If no doc impact, enter “N/A” plus brief explanation of why there’s no doc impact

## Training
> Link to the PR for changes to the training content in https://github.com/wso2/WSO2-Training, if applicable

## Certification
> Type “Sent” when you have provided new/updated certification questions, plus four answers for each question (correct answer highlighted in bold), based on this change. Certification questions/answers should be sent to certification@wso2.com and NOT pasted in this PR. If there is no impact on certification exams, type “N/A” and explain why.

## Marketing
> Link to drafts of marketing content that will describe and promote this feature, including product page changes, technical articles, blog posts, videos, etc., if applicable

## Automation tests
 - Unit tests 
   > Code coverage information
 - Integration tests
   > Details about the test cases and coverage

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes/no
 - Ran FindSecurityBugs plugin and verified report? yes/no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes/no

## Samples
> Provide high-level details about the samples related to this feature

## Related PRs
> List any other related PRs

## Migrations (if applicable)
> Describe migration steps and platforms on which migration has been tested

## Test environment
> List all JDK versions, operating systems, databases, and browser/versions on which this feature/fix was tested
 
## Learning
> Describe the research phase and any blog posts, patterns, libraries, or add-ons you used to solve the problem.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request fixes a memory leak in the LanguageServerWrapper where language server processes were not being properly shut down when file editors were closed after the file had been moved or renamed.

## Changes

**Enhanced editor-to-server resolution** (`forEditor` method):
- Added fallback logic to locate the language server wrapper even when an editor's file path has changed since the editor was originally connected
- When the direct URI-based lookup fails, the code now scans existing wrappers to find one that already tracks the editor, ensuring the wrapper can be found regardless of URI drift

**Improved mapping cleanup on editor disconnect** (`disconnect` method):
- Modified the disconnection logic to use the URI that was captured when the editor was initially connected, rather than computing the URI from the editor's current path
- This ensures that internal mappings (`uriToEditorManagers`, `urisUnderLspControl`, and `uriToLanguageServerWrapper`) are correctly cleaned up even after the file has been moved or renamed
- When the last editor is disconnected, the language server is now properly shut down and exited, preventing server processes from remaining in memory

## Impact

These changes improve stability and resource management by ensuring that language server processes are properly cleaned up when editors are closed, eliminating orphaned server instances that would otherwise remain running in the background.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/lsp4intellij/pull/402)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->