### PR TITLE
Rework threading model with per-server dispatchers and fix concurrency bugs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 *.zip
 *.ps1
 target/
+.intellijPlatform/

--- a/build.gradle
+++ b/build.gradle
@@ -1,4 +1,5 @@
 import java.util.Calendar
+import org.jetbrains.intellij.platform.gradle.TestFrameworkType
 
 plugins {
     id 'java'
@@ -43,6 +44,7 @@ dependencies {
     intellijPlatform {
         intellijIdeaCommunity('2024.3')
         pluginVerifier()
+        testFramework(TestFrameworkType.Platform.INSTANCE)
     }
 
     implementation 'org.eclipse.lsp4j:org.eclipse.lsp4j:0.23.1'

--- a/docs/adr/0001-threading-and-concurrency-model.md
+++ b/docs/adr/0001-threading-and-concurrency-model.md
@@ -1,0 +1,109 @@
+# ADR 0001: Threading and concurrency model
+
+- Status: Accepted
+- Date: 2026-07-04
+
+## Context
+
+Before this decision, the library had the following threading behavior:
+
+- All asynchronous work for every language server of every project was submitted to one global
+  single-threaded executor (`ApplicationUtils.pool()`). One slow or hung server delayed requests and
+  document-synchronization notifications of all other servers.
+- Several request paths blocked the Swing event dispatch thread (EDT) with `Future.get(timeout)`
+  calls of up to several seconds (code actions, rename, ctrl-click navigation, find usages), which
+  froze the IDE UI for the duration of the wait.
+- The try/catch block implementing the timeout and error policy for blocking waits was duplicated at
+  nine call sites with small accidental differences.
+- Executors were created per listener or per launch and never shut down, leaking one thread per
+  editor and one thread pool per server start.
+- Collections shared between the EDT, the executor thread, and lsp4j reader threads were
+  unsynchronized (`HashSet`, `HashMap`, plain `int` counters).
+
+## Decision
+
+### 1. One dispatcher thread per server
+
+Each `LanguageServerWrapper` owns a single-threaded executor (a daemon thread named
+`lsp4intellij-<ext>`), exposed as `wrapper.pool(Runnable)`. All work belonging to one server runs on
+its dispatcher: request waits, `didOpen`/`didChange`/`didClose`/`didSave` notifications, editor
+connect/disconnect, and restart.
+
+Rationale: the LSP requires client-to-server messages of one session to be ordered (a `didChange`
+must not overtake the `didOpen` of the same document). A single thread per server preserves that
+order without cross-server contention. The dispatcher is shut down in `dispose()`; tasks submitted
+after disposal are dropped.
+
+The global `ApplicationUtils.pool()` remains only for work that has no wrapper yet: resolving which
+server definition matches an opened editor, and VFS-driven file events.
+
+### 2. All blocking request waits go through `RequestExecutor`
+
+`RequestExecutor.waitFor(future, timeoutType)` is the only place that blocks on a request future.
+It implements the complete policy:
+
+- waits with the timeout configured for the request type (`Timeouts`),
+- reports success or failure to the server status widget,
+- `TimeoutException`: log, report failure, return null,
+- `InterruptedException`: restore the interrupt flag and return null without invoking the crash
+  handler (the dispatcher is interrupted during disposal; a crash-triggered reconnect at that point
+  would restart a server that is being torn down),
+- `JsonRpcException` / `ExecutionException`: route to `wrapper.crashed(e)`,
+- returns null for "no result"; callers must handle null.
+
+New request code must not call `Future.get` directly.
+
+### 3. The EDT never waits for a server
+
+`RequestExecutor.waitFor` must not be called on the EDT. The pattern for a feature triggered from
+the UI is:
+
+1. capture editor state (offsets, positions) on the calling thread, using a read action where
+   required;
+2. submit the request work to `wrapper.pool(...)`;
+3. apply results (annotations, hints, markup, navigation, popups) on the EDT via `invokeLater`,
+   re-checking `editor.isDisposed()` inside the runnable.
+
+Write actions run on the EDT. Code that must open or close editors from a background thread
+marshals that step with `invokeAndWait`; it must not hold the read lock while doing so
+(`EditorEventManager.openEditor` is the reference implementation).
+
+### 4. Executor lifecycle
+
+- The lsp4j launcher executor is created in `start()` and shut down in `stop()`.
+- The wrapper dispatcher is shut down in `dispose()`.
+- Listener debouncing uses the shared application scheduled pool
+  (`AppExecutorUtil.getAppScheduledExecutorService()`); creating a thread or executor per editor,
+  per listener, or per request is not allowed.
+- `stop(boolean)` is `synchronized`, so concurrent stop attempts (a stop queued on the dispatcher,
+  `dispose()`, the JVM shutdown hook) run one at a time and the status guard turns later callers
+  into no-ops. On the last editor disconnect, `stop` is submitted to the dispatcher instead of
+  called inline, so the queued `didClose` notification is sent before the shutdown request.
+
+### 5. Shared state is thread-safe by construction
+
+State reachable from more than one of {EDT, dispatcher, lsp4j reader threads} uses concurrent
+collections (`ConcurrentHashMap`, `ConcurrentHashMap.newKeySet()`) or atomic types
+(`AtomicInteger` for crash counts and document versions). New fields on `LanguageServerWrapper`,
+`EditorEventManager`, or `DocumentEventManager` follow the same rule.
+
+## Consequences
+
+- The IDE UI cannot be frozen by a slow language server: no code path blocks the EDT on a server
+  response.
+- Requests and notifications of one server are processed in submission order. A blocking wait on
+  the dispatcher delays other work queued for the same server by up to that request's timeout; this
+  is accepted for now. Removing it requires composing `CompletableFuture` chains instead of
+  blocking waits, which is planned as a later change and does not alter the rules above.
+- Timeout values, failure reporting, and crash routing behave identically for every request type,
+  and change in one file.
+- Tests can drive a full editor-open to server-shutdown cycle deterministically
+  (`LspServerIntegrationTest`), because each server's work is confined to one known thread.
+
+## Rules for new code
+
+1. Per-server work goes through `wrapper.pool(...)`, not a new executor and not the global pool.
+2. Blocking on a request future is done only via `RequestExecutor.waitFor`, never on the EDT.
+3. UI mutation happens on the EDT via `invokeLater`, with an `editor.isDisposed()` re-check.
+4. No per-editor, per-listener, or per-request threads; use the shared application pools.
+5. Fields accessed from more than one thread use concurrent or atomic types.

--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -388,6 +388,10 @@ public class IntellijLanguageClient implements ApplicationComponent, Disposable 
     public static void didChangeConfiguration(@NotNull DidChangeConfigurationParams params, @NotNull Project project) {
         final Set<LanguageServerWrapper> serverWrappers = IntellijLanguageClient.getProjectToLanguageWrappers()
                 .get(FileUtils.projectToUri(project));
+        if (serverWrappers == null) {
+            LOG.warn("No language servers registered for project " + project.getName());
+            return;
+        }
         serverWrappers.forEach(s -> s.getRequestManager().didChangeConfiguration(params));
     }
 

--- a/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
+++ b/src/main/java/org/wso2/lsp4intellij/IntellijLanguageClient.java
@@ -257,7 +257,9 @@ public class IntellijLanguageClient implements ApplicationComponent, Disposable 
                     project, new ImmutablePair<>(ext, projectUri), serverDefinition);
 
             LOG.info("Adding file " + fileName);
-            wrapper.connect(editor);
+            // Connecting (which may start the server) runs on the wrapper's own dispatcher so that a slow
+            // server start does not block editor events of other servers.
+            wrapper.pool(() -> wrapper.connect(editor));
         });
     }
 
@@ -306,7 +308,7 @@ public class IntellijLanguageClient implements ApplicationComponent, Disposable 
             LanguageServerWrapper serverWrapper = LanguageServerWrapper.forEditor(editor);
             if (serverWrapper != null) {
                 LOG.info("Disconnecting " + FileUtils.editorToURIString(editor));
-                serverWrapper.disconnect(editor);
+                serverWrapper.pool(() -> serverWrapper.disconnect(editor));
             }
         });
     }

--- a/src/main/java/org/wso2/lsp4intellij/actions/LSPReferencesAction.java
+++ b/src/main/java/org/wso2/lsp4intellij/actions/LSPReferencesAction.java
@@ -49,6 +49,9 @@ import java.util.List;
 
 import javax.swing.JLabel;
 
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableReadAction;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeLater;
+
 /**
  * Action for references / see usages (SHIFT+ALT+F7).
  */
@@ -62,24 +65,30 @@ public class LSPReferencesAction extends DumbAwareAction {
             if (eventManager == null) {
                 return;
             }
-            List<PsiElement2UsageTargetAdapter> targets = new ArrayList<>();
-            Pair<List<PsiElement>, List<VirtualFile>> references = eventManager
-                    .references(editor.getCaretModel().getCurrentCaret().getOffset());
-            if (references.first != null && references.second != null) {
-                references.first.forEach(element -> targets.add(new PsiElement2UsageTargetAdapter(element, true)));
-            }
-            showReferences(editor, targets, editor.getCaretModel().getCurrentCaret().getLogicalPosition());
+            forManagerAndOffset(eventManager, editor.getCaretModel().getCurrentCaret().getOffset());
         }
     }
 
     public void forManagerAndOffset(EditorEventManager manager, int offset) {
-        List<PsiElement2UsageTargetAdapter> targets = new ArrayList<>();
-        Pair<List<PsiElement>, List<VirtualFile>> references = manager.references(offset);
-        if (references.first != null && references.second != null) {
-            references.first.forEach(element -> targets.add(new PsiElement2UsageTargetAdapter(element, true)));
-        }
-        Editor editor = manager.editor;
-        showReferences(editor, targets, editor.offsetToLogicalPosition(offset));
+        // The references lookup blocks on the server response, so it runs on the wrapper's
+        // dispatcher; only showing the results runs on the EDT.
+        manager.wrapper.pool(() -> {
+            Pair<List<PsiElement>, List<VirtualFile>> references = manager.references(offset);
+            List<PsiElement2UsageTargetAdapter> targets = computableReadAction(() -> {
+                List<PsiElement2UsageTargetAdapter> adapters = new ArrayList<>();
+                if (references.first != null && references.second != null) {
+                    references.first.forEach(element ->
+                            adapters.add(new PsiElement2UsageTargetAdapter(element, true)));
+                }
+                return adapters;
+            });
+            Editor editor = manager.editor;
+            invokeLater(() -> {
+                if (!editor.isDisposed()) {
+                    showReferences(editor, targets, editor.offsetToLogicalPosition(offset));
+                }
+            });
+        });
     }
 
     private void showReferences(Editor editor, List<PsiElement2UsageTargetAdapter> targets, LogicalPosition position) {

--- a/src/main/java/org/wso2/lsp4intellij/client/connection/ProcessStreamConnectionProvider.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/connection/ProcessStreamConnectionProvider.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 /**
@@ -95,8 +96,18 @@ public class ProcessStreamConnectionProvider implements StreamConnectionProvider
     }
 
     public void stop() {
-        if (process != null) {
-            process.destroy();
+        if (process == null) {
+            return;
+        }
+        process.destroy();
+        try {
+            // Kill the process if it does not terminate within the grace period.
+            if (!process.waitFor(5, TimeUnit.SECONDS)) {
+                process.destroyForcibly();
+            }
+        } catch (InterruptedException e) {
+            process.destroyForcibly();
+            Thread.currentThread().interrupt();
         }
     }
 

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/DefaultRequestManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/DefaultRequestManager.java
@@ -396,7 +396,10 @@ public class DefaultRequestManager implements RequestManager {
     public void didClose(DidCloseTextDocumentParams params) {
         if (checkStatus()) {
             try {
-                if (Optional.ofNullable(textDocumentOptions).map(TextDocumentSyncOptions::getOpenClose).orElse(false)) {
+                // A bare sync kind implies open/close notifications (LSP spec), consistent with didOpen.
+                if ((textDocumentSyncKind != null && textDocumentSyncKind != TextDocumentSyncKind.None) ||
+                        Optional.ofNullable(textDocumentOptions).map(TextDocumentSyncOptions::getOpenClose)
+                                .orElse(false)) {
                     textDocumentService.didClose(params);
                 }
             } catch (Exception e) {

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -481,8 +481,12 @@ public class LanguageServerWrapper {
      * The shutdown request is sent from the client to the server. It asks the server to shut down, but to not exit \
      * (otherwise the response might not be delivered correctly to the client).
      * Only if the exit flag is true, particular server instance will exit.
+     *
+     * Synchronized so that concurrent stops (for example a stop queued on the dispatcher and a direct
+     * stop from dispose or the shutdown hook) cannot both enter cleanup; the status guard turns the
+     * second caller into a no-op.
      */
-    public void stop(boolean exit) {
+    public synchronized void stop(boolean exit) {
         if (this.status == STOPPED || this.status == STOPPING) {
             return;
         }

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -764,7 +764,9 @@ public class LanguageServerWrapper {
         }
 
         if (connectedEditors.isEmpty()) {
-            stop(true);
+            // Deferred to the pool so that the didClose notification queued by documentClosed()
+            // is sent before the server is shut down.
+            pool(() -> stop(true));
         }
     }
 
@@ -801,7 +803,9 @@ public class LanguageServerWrapper {
             uriToLanguageServerWrapper.remove(new ImmutablePair<>(sanitizeURI(uri), sanitizeURI(projectUri)));
         }
         if (connectedEditors.isEmpty()) {
-            stop(true);
+            // Deferred to the pool so that the didClose notification queued by documentClosed()
+            // is sent before the server is shut down.
+            pool(() -> stop(true));
         }
     }
 

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -92,6 +92,7 @@ import org.wso2.lsp4intellij.listeners.DocumentListenerImpl;
 import org.wso2.lsp4intellij.listeners.EditorMouseListenerImpl;
 import org.wso2.lsp4intellij.listeners.EditorMouseMotionListenerImpl;
 import org.wso2.lsp4intellij.listeners.LSPCaretListenerImpl;
+import org.wso2.lsp4intellij.requests.RequestExecutor;
 import org.wso2.lsp4intellij.requests.Timeouts;
 import org.wso2.lsp4intellij.statusbar.LSPServerStatusWidget;
 import org.wso2.lsp4intellij.statusbar.LSPServerStatusWidgetFactory;
@@ -129,7 +130,6 @@ import static org.wso2.lsp4intellij.requests.Timeouts.INIT;
 import static org.wso2.lsp4intellij.requests.Timeouts.SHUTDOWN;
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableReadAction;
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeLater;
-import static org.wso2.lsp4intellij.utils.ApplicationUtils.pool;
 import static org.wso2.lsp4intellij.utils.FileUtils.editorToProjectFolderUri;
 import static org.wso2.lsp4intellij.utils.FileUtils.editorToURIString;
 import static org.wso2.lsp4intellij.utils.FileUtils.reloadEditors;
@@ -154,6 +154,9 @@ public class LanguageServerWrapper {
     private RequestManager requestManager;
     private InitializeResult initializeResult;
     private Future<?> launcherFuture;
+    private ExecutorService launcherExecutor;
+    private final ExecutorService dispatcher;
+    private final RequestExecutor requestExecutor = new RequestExecutor(this);
     private CompletableFuture<InitializeResult> initializeFuture;
     private boolean capabilitiesAlreadyRequested = false;
     private final AtomicInteger crashCount = new AtomicInteger(0);
@@ -180,7 +183,31 @@ public class LanguageServerWrapper {
         // base path if the project is disposed.
         this.projectRootPath = project.getBasePath();
         this.extManager = extManager;
+        this.dispatcher = Executors.newSingleThreadExecutor(r -> {
+            Thread thread = new Thread(r, "lsp4intellij-" + serverDefinition.ext);
+            thread.setDaemon(true);
+            return thread;
+        });
         projectToLanguageServerWrapper.put(project, this);
+    }
+
+    /**
+     * Submits a task to this wrapper's dispatcher thread. Tasks of one server are executed in submission
+     * order, but do not block tasks of other servers. Tasks submitted after {@link #dispose()} are dropped.
+     */
+    public void pool(Runnable task) {
+        try {
+            dispatcher.submit(task);
+        } catch (java.util.concurrent.RejectedExecutionException e) {
+            LOG.debug("Task submitted after wrapper disposal was dropped", e);
+        }
+    }
+
+    /**
+     * @return The request executor which enforces the timeout/crash policy for blocking request waits
+     */
+    public RequestExecutor getRequestExecutor() {
+        return requestExecutor;
     }
 
     /**
@@ -482,6 +509,10 @@ public class LanguageServerWrapper {
             if (launcherFuture != null) {
                 launcherFuture.cancel(true);
             }
+            if (launcherExecutor != null) {
+                launcherExecutor.shutdownNow();
+                launcherExecutor = null;
+            }
             if (serverDefinition != null) {
                 serverDefinition.stop(projectRootPath);
             }
@@ -537,6 +568,7 @@ public class LanguageServerWrapper {
                 OutputStream outputStream = streams.getValue();
                 InitializeParams initParams = getInitParams();
                 ExecutorService executorService = Executors.newCachedThreadPool();
+                launcherExecutor = executorService;
                 MessageHandler messageHandler = new MessageHandler(
                         serverDefinition.getServerListener(), () -> getStatus() != STOPPED);
                 if (extManager != null && extManager.getExtendedServerInterface() != null) {
@@ -733,6 +765,7 @@ public class LanguageServerWrapper {
     public synchronized void dispose() {
         stop(true);
         removeWidget();
+        dispatcher.shutdownNow();
         projectToLanguageServerWrapper.remove(project);
         IntellijLanguageClient.removeWrapper(this);
     }

--- a/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
+++ b/src/main/java/org/wso2/lsp4intellij/client/languageserver/wrapper/LanguageServerWrapper.java
@@ -105,7 +105,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -118,6 +117,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.wso2.lsp4intellij.client.languageserver.ServerStatus.INITIALIZED;
 import static org.wso2.lsp4intellij.client.languageserver.ServerStatus.STARTED;
@@ -143,11 +143,12 @@ public class LanguageServerWrapper {
     public LanguageServerDefinition serverDefinition;
     private final LSPExtensionManager extManager;
     private final Project project;
-    private final HashSet<Editor> toConnect = new HashSet<>();
+    // These collections are mutated from the EDT, the background pool, and lsp4j threads.
+    private final Set<Editor> toConnect = ConcurrentHashMap.newKeySet();
     private final String projectRootPath;
-    private final HashSet<String> urisUnderLspControl = new HashSet<>();
-    private final HashSet<Editor> connectedEditors = new HashSet<>();
-    private final Map<String, Set<EditorEventManager>> uriToEditorManagers = new HashMap<>();
+    private final Set<String> urisUnderLspControl = ConcurrentHashMap.newKeySet();
+    private final Set<Editor> connectedEditors = ConcurrentHashMap.newKeySet();
+    private final Map<String, Set<EditorEventManager>> uriToEditorManagers = new ConcurrentHashMap<>();
     private LanguageServer languageServer;
     private LanguageClient client;
     private RequestManager requestManager;
@@ -155,7 +156,7 @@ public class LanguageServerWrapper {
     private Future<?> launcherFuture;
     private CompletableFuture<InitializeResult> initializeFuture;
     private boolean capabilitiesAlreadyRequested = false;
-    private int crashCount = 0;
+    private final AtomicInteger crashCount = new AtomicInteger(0);
     private volatile boolean alreadyShownTimeout = false;
     private volatile boolean alreadyShownCrash = false;
     private volatile ServerStatus status = STOPPED;
@@ -668,8 +669,7 @@ public class LanguageServerWrapper {
     }
 
     public void crashed(Exception e) {
-        crashCount += 1;
-        if (crashCount <= 3) {
+        if (crashCount.incrementAndGet() <= 3) {
             reconnect();
         } else {
             invokeLater(() -> {
@@ -696,7 +696,7 @@ public class LanguageServerWrapper {
                     }
                 }
                 alreadyShownCrash = true;
-                crashCount = 0;
+                crashCount.set(0);
             });
         }
     }

--- a/src/main/java/org/wso2/lsp4intellij/contributors/psi/LSPPsiElement.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/psi/LSPPsiElement.java
@@ -255,7 +255,7 @@ public class LSPPsiElement implements PsiNameIdentifierOwner, NavigatablePsiElem
      * @return true if the text is equal, false otherwise.
      */
     public boolean textMatches(@NotNull CharSequence text) {
-        return getText() == text;
+        return getText().contentEquals(text);
     }
 
     //Q: get rid of these methods?

--- a/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
@@ -34,7 +34,6 @@ import org.eclipse.lsp4j.TextDocumentItem;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
-import org.wso2.lsp4intellij.utils.ApplicationUtils;
 import org.wso2.lsp4intellij.utils.DocumentUtils;
 import org.wso2.lsp4intellij.utils.FileUtils;
 
@@ -126,7 +125,7 @@ public class DocumentEventManager {
         } else if (syncKind == TextDocumentSyncKind.Full) {
             changesParams.getContentChanges().get(0).setText(document.getText());
         }
-        ApplicationUtils.pool(() -> wrapper.getRequestManager().didChange(changesParams));
+        wrapper.pool(() -> wrapper.getRequestManager().didChange(changesParams));
     }
 
     public void documentOpened() {

--- a/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/DocumentEventManager.java
@@ -39,8 +39,9 @@ import org.wso2.lsp4intellij.utils.DocumentUtils;
 import org.wso2.lsp4intellij.utils.FileUtils;
 
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
 
 public class DocumentEventManager {
     private final Document document;
@@ -48,10 +49,11 @@ public class DocumentEventManager {
     private final TextDocumentSyncKind syncKind;
     private final LanguageServerWrapper wrapper;
     private final TextDocumentIdentifier identifier;
-    private int version = -1;
+    // Accessed from the EDT, the background pool, and lsp4j threads.
+    private final AtomicInteger version = new AtomicInteger(-1);
     protected static final Logger LOG = Logger.getInstance(DocumentEventManager.class);
 
-    private final Set<Document> openDocuments = new HashSet<>();
+    private final Set<Document> openDocuments = ConcurrentHashMap.newKeySet();
 
     DocumentEventManager(Document document, DocumentListener documentListener,
                          TextDocumentSyncKind syncKind, LanguageServerWrapper wrapper) {
@@ -71,7 +73,7 @@ public class DocumentEventManager {
     }
 
     public int getDocumentVersion() {
-        return this.version;
+        return this.version.get();
     }
 
     public void documentChanged(DocumentEvent event) {
@@ -82,7 +84,7 @@ public class DocumentEventManager {
         changesParams.getTextDocument().setUri(identifier.getUri());
 
 
-        changesParams.getTextDocument().setVersion(++version);
+        changesParams.getTextDocument().setVersion(version.incrementAndGet());
 
         if (syncKind == TextDocumentSyncKind.Incremental) {
             TextDocumentContentChangeEvent changeEvent = changesParams.getContentChanges().get(0);
@@ -136,7 +138,7 @@ public class DocumentEventManager {
                     FileDocumentManager.getInstance().getFile(document).getName());
             wrapper.getRequestManager().didOpen(new DidOpenTextDocumentParams(new TextDocumentItem(identifier.getUri(),
                     wrapper.serverDefinition.languageIdFor(extension),
-                    ++version,
+                    version.incrementAndGet(),
                     document.getText())));
         }
     }

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -30,6 +30,7 @@ import com.intellij.lang.annotation.Annotation;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.HighlightSeverity;
 import com.intellij.openapi.actionSystem.ActionManager;
+import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.CommandProcessor;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
@@ -103,7 +104,6 @@ import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WillSaveTextDocumentParams;
 import org.eclipse.lsp4j.WorkspaceEdit;
-import org.eclipse.lsp4j.jsonrpc.JsonRpcException;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.messages.Tuple;
 import org.jetbrains.annotations.NotNull;
@@ -135,9 +135,6 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -147,7 +144,6 @@ import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getCtrlRange;
 import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getIsCtrlDown;
 import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getIsKeyPressed;
 import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.setCtrlRange;
-import static org.wso2.lsp4intellij.requests.Timeout.getTimeout;
 import static org.wso2.lsp4intellij.requests.Timeouts.CODEACTION;
 import static org.wso2.lsp4intellij.requests.Timeouts.COMPLETION;
 import static org.wso2.lsp4intellij.requests.Timeouts.DEFINITION;
@@ -158,8 +154,8 @@ import static org.wso2.lsp4intellij.requests.Timeouts.SIGNATURE;
 import static org.wso2.lsp4intellij.requests.Timeouts.WILLSAVE;
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableReadAction;
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableWriteAction;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeAndWait;
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeLater;
-import static org.wso2.lsp4intellij.utils.ApplicationUtils.pool;
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.writeAction;
 import static org.wso2.lsp4intellij.utils.DocumentUtils.toEither;
 import static org.wso2.lsp4intellij.utils.GUIUtils.createAndShowEditorHint;
@@ -331,7 +327,7 @@ public class EditorEventManager {
                         getCtrlRange().dispose();
                     }
                     setCtrlRange(null);
-                    pool(() -> requestAndShowDoc(lPos, e.getMouseEvent().getPoint()));
+                    wrapper.pool(() -> requestAndShowDoc(lPos, e.getMouseEvent().getPoint()));
                 } else if (getCtrlRange().definitionContainsOffset(offset)) {
                     createAndShowEditorHint(editor, "Click to show usages", editor.offsetToXY(offset));
                 } else {
@@ -369,8 +365,7 @@ public class EditorEventManager {
         }
     }
 
-    private void createCtrlRange(Position logicalPos, Range range) {
-        Location location = requestDefinition(logicalPos);
+    private void createCtrlRange(Position logicalPos, Range range, Location location) {
         if (location == null || location.getRange() == null || editor.isDisposed()) {
             return;
         }
@@ -407,27 +402,16 @@ public class EditorEventManager {
         CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>> request =
                 wrapper.getRequestManager().definition(params);
 
-        if (request == null) {
+        Either<List<? extends Location>, List<? extends LocationLink>> definition =
+                wrapper.getRequestExecutor().waitFor(request, DEFINITION);
+        if (definition == null) {
             return null;
         }
-        try {
-            Either<List<? extends Location>, List<? extends LocationLink>> definition =
-                    request.get(getTimeout(DEFINITION), TimeUnit.MILLISECONDS);
-            wrapper.notifySuccess(DEFINITION);
-            if (definition.isLeft() && !definition.getLeft().isEmpty()) {
-                return definition.getLeft().get(0);
-            } else if (definition.isRight() && !definition.getRight().isEmpty()) {
-                var def = definition.getRight().get(0);
-                return new Location(def.getTargetUri(), def.getTargetRange());
-            }
-        } catch (TimeoutException e) {
-            LOG.warn(e);
-            wrapper.notifyFailure(DEFINITION);
-            return null;
-        } catch (InterruptedException | JsonRpcException | ExecutionException e) {
-            LOG.warn(e);
-            wrapper.crashed(e);
-            return null;
+        if (definition.isLeft() && !definition.getLeft().isEmpty()) {
+            return definition.getLeft().get(0);
+        } else if (definition.isRight() && !definition.getRight().isEmpty()) {
+            var def = definition.getRight().get(0);
+            return new Location(def.getTargetUri(), def.getTargetRange());
         }
         return null;
     }
@@ -438,7 +422,8 @@ public class EditorEventManager {
 
     /**
      * Returns the references given the position of the word to search for.
-     * Must be called from main thread
+     * May be called from any thread; opening and closing editors for reference locations is marshaled
+     * to the event dispatch thread. When called from a background thread, the read lock must not be held.
      *
      * @param offset The offset in the editor
      * @return An array of PsiElement
@@ -451,56 +436,65 @@ public class EditorEventManager {
         params.setPosition(lspPos);
         params.setTextDocument(identifier);
         CompletableFuture<List<? extends Location>> request = wrapper.getRequestManager().references(params);
-        if (request != null) {
-            try {
-                List<? extends Location> res = request.get(getTimeout(REFERENCES), TimeUnit.MILLISECONDS);
-                wrapper.notifySuccess(REFERENCES);
-                if (res != null && res.size() > 0) {
-                    List<VirtualFile> openedEditors = new ArrayList<>();
-                    List<PsiElement> elements = new ArrayList<>();
-                    res.forEach(l -> {
-                        Position start = l.getRange().getStart();
-                        Position end = l.getRange().getEnd();
-                        String uri = FileUtils.sanitizeURI(l.getUri());
-                        VirtualFile file = FileUtils.virtualFileFromURI(uri);
-                        Editor curEditor = FileUtils.editorFromUri(uri, project);
-                        if (curEditor == null && file != null) {
-                            OpenFileDescriptor descriptor = new OpenFileDescriptor(
-                                    project, file, start.getLine(), start.getCharacter());
-                            curEditor = computableWriteAction(
-                                    () -> FileEditorManager.getInstance(project).openTextEditor(descriptor, false));
-                            openedEditors.add(file);
-                        }
-                        if (curEditor == null) {
-                            LOG.warn("Error occurred in LSP references.");
-                            return;
-                        }
-                        int logicalStart = DocumentUtils.lspPosToOffset(curEditor, start);
-                        int logicalEnd = DocumentUtils.lspPosToOffset(curEditor, end);
-                        String name = curEditor.getDocument().getText(new TextRange(logicalStart, logicalEnd));
-                        elements.add(new LSPPsiElement(name, project, logicalStart, logicalEnd,
-                                PsiDocumentManager.getInstance(project).getPsiFile(curEditor.getDocument())));
-                    });
-                    if (close) {
-                        writeAction(
-                                () -> openedEditors.forEach(f -> FileEditorManager.getInstance(project).closeFile(f)));
-                        openedEditors.clear();
-                    }
-                    return new Pair<>(elements, openedEditors);
-                } else {
-                    return new Pair<>(null, null);
-                }
-            } catch (TimeoutException e) {
-                LOG.warn(e);
-                wrapper.notifyFailure(REFERENCES);
-                return new Pair<>(null, null);
-            } catch (InterruptedException | JsonRpcException | ExecutionException e) {
-                LOG.warn(e);
-                wrapper.crashed(e);
-                return new Pair<>(null, null);
-            }
+        List<? extends Location> res = wrapper.getRequestExecutor().waitFor(request, REFERENCES);
+        if (res == null || res.isEmpty()) {
+            return new Pair<>(null, null);
         }
-        return new Pair<>(null, null);
+        List<VirtualFile> openedEditors = new ArrayList<>();
+        List<PsiElement> elements = new ArrayList<>();
+        res.forEach(l -> {
+            Position start = l.getRange().getStart();
+            Position end = l.getRange().getEnd();
+            String uri = FileUtils.sanitizeURI(l.getUri());
+            VirtualFile file = FileUtils.virtualFileFromURI(uri);
+            Editor curEditor = FileUtils.editorFromUri(uri, project);
+            if (curEditor == null && file != null) {
+                OpenFileDescriptor descriptor = new OpenFileDescriptor(
+                        project, file, start.getLine(), start.getCharacter());
+                curEditor = openEditor(descriptor);
+                if (curEditor != null) {
+                    openedEditors.add(file);
+                }
+            }
+            if (curEditor == null) {
+                LOG.warn("Error occurred in LSP references.");
+                return;
+            }
+            Editor refEditor = curEditor;
+            elements.add(computableReadAction(() -> {
+                int logicalStart = DocumentUtils.lspPosToOffset(refEditor, start);
+                int logicalEnd = DocumentUtils.lspPosToOffset(refEditor, end);
+                String name = refEditor.getDocument().getText(new TextRange(logicalStart, logicalEnd));
+                return new LSPPsiElement(name, project, logicalStart, logicalEnd,
+                        PsiDocumentManager.getInstance(project).getPsiFile(refEditor.getDocument()));
+            }));
+        });
+        if (close && !openedEditors.isEmpty()) {
+            invokeAndWait(() -> writeAction(
+                    () -> openedEditors.forEach(f -> FileEditorManager.getInstance(project).closeFile(f))));
+            openedEditors.clear();
+        }
+        return new Pair<>(elements, openedEditors);
+    }
+
+    /**
+     * Opens an editor for the given descriptor. Runs directly when called on the event dispatch thread;
+     * otherwise the opening is marshaled to the event dispatch thread and this method blocks until done.
+     */
+    private Editor openEditor(OpenFileDescriptor descriptor) {
+        if (ApplicationManager.getApplication().isDispatchThread()) {
+            return computableWriteAction(
+                    () -> FileEditorManager.getInstance(project).openTextEditor(descriptor, false));
+        }
+        if (ApplicationManager.getApplication().isReadAccessAllowed()) {
+            // Blocking on the event dispatch thread while holding the read lock would deadlock.
+            LOG.warn("Cannot open an editor for " + descriptor.getFile() + " from inside a read action");
+            return null;
+        }
+        Editor[] result = new Editor[1];
+        invokeAndWait(() -> result[0] = computableWriteAction(
+                () -> FileEditorManager.getInstance(project).openTextEditor(descriptor, false)));
+        return result[0];
     }
 
     /**
@@ -586,42 +580,12 @@ public class EditorEventManager {
         CodeActionContext context = new CodeActionContext(diagnosticContext);
         params.setContext(context);
         CompletableFuture<List<Either<Command, CodeAction>>> future = wrapper.getRequestManager().codeAction(params);
-        if (future != null) {
-            try {
-                List<Either<Command, CodeAction>> res = future.get(getTimeout(CODEACTION), TimeUnit.MILLISECONDS);
-                wrapper.notifySuccess(CODEACTION);
-                return res;
-            } catch (TimeoutException e) {
-                LOG.warn(e);
-                wrapper.notifyFailure(CODEACTION);
-                return null;
-            } catch (InterruptedException | JsonRpcException | ExecutionException e) {
-                LOG.warn(e);
-                wrapper.crashed(e);
-                return null;
-            }
-        }
-        return null;
+        return wrapper.getRequestExecutor().waitFor(future, CODEACTION);
     }
 
     public CodeAction resolvedCodeAction(CodeAction codeAction) {
         CompletableFuture<CodeAction> future = wrapper.getRequestManager().resolveCodeAction(codeAction);
-        if (future != null) {
-            try {
-                CodeAction res = future.get(getTimeout(CODEACTION), TimeUnit.MILLISECONDS);
-                wrapper.notifySuccess(CODEACTION);
-                return res;
-            } catch (TimeoutException e) {
-                LOG.warn(e);
-                wrapper.notifyFailure(CODEACTION);
-                return null;
-            } catch (InterruptedException | JsonRpcException | ExecutionException e) {
-                LOG.warn(e);
-                wrapper.crashed(e);
-                return null;
-            }
-        }
-        return null;
+        return wrapper.getRequestExecutor().waitFor(future, CODEACTION);
     }
 
     /**
@@ -635,17 +599,13 @@ public class EditorEventManager {
         LogicalPosition lPos = editor.getCaretModel().getCurrentCaret().getLogicalPosition();
         Point point = editor.logicalPositionToXY(lPos);
         SignatureHelpParams params = new SignatureHelpParams(identifier, DocumentUtils.logicalToLSPPos(lPos, editor));
-        pool(() -> {
+        wrapper.pool(() -> {
             CompletableFuture<SignatureHelp> future = wrapper.getRequestManager().signatureHelp(params);
-            if (future == null) {
+            SignatureHelp signatureResp = wrapper.getRequestExecutor().waitFor(future, SIGNATURE);
+            if (signatureResp == null) {
                 return;
             }
             try {
-                SignatureHelp signatureResp = future.get(getTimeout(SIGNATURE), TimeUnit.MILLISECONDS);
-                wrapper.notifySuccess(SIGNATURE);
-                if (signatureResp == null) {
-                    return;
-                }
                 List<SignatureInformation> signatures = signatureResp.getSignatures();
                 if (signatures == null || signatures.isEmpty()) {
                     return;
@@ -700,12 +660,6 @@ public class EditorEventManager {
                         editor, builder.toString(), point,
                         HintManager.UNDER, HintManager.HIDE_BY_OTHER_HINT));
 
-            } catch (TimeoutException e) {
-                LOG.warn(e);
-                wrapper.notifyFailure(SIGNATURE);
-            } catch (JsonRpcException | ExecutionException | InterruptedException e) {
-                LOG.warn(e);
-                wrapper.crashed(e);
             } catch (Exception e) {
                 LOG.warn("Internal error occurred when processing signature help");
             }
@@ -727,7 +681,7 @@ public class EditorEventManager {
      * Reformat the whole document.
      */
     public void reformat() {
-        pool(() -> {
+        wrapper.pool(() -> {
             if (editor.isDisposed()) {
                 return;
             }
@@ -754,7 +708,7 @@ public class EditorEventManager {
      * Reformat the text currently selected in the editor.
      */
     public void reformatSelection() {
-        pool(() -> {
+        wrapper.pool(() -> {
             if (editor.isDisposed()) {
                 return;
             }
@@ -799,41 +753,35 @@ public class EditorEventManager {
      * @param renameTo The new name
      */
     public void rename(String renameTo, int offset) {
-        pool(() -> {
+        wrapper.pool(() -> {
             if (editor.isDisposed()) {
                 return;
             }
             VirtualFile[] openedFiles = FileEditorManager.getInstance(project).getOpenFiles();
-            invokeLater(() -> {
-                Pair<List<PsiElement>, List<VirtualFile>> references = references(offset, true, false);
-                List<VirtualFile> toClose = new ArrayList<>();
+            Pair<List<PsiElement>, List<VirtualFile>> references = references(offset, true, false);
+            List<VirtualFile> toClose = new ArrayList<>();
+            if (references.getSecond() != null) {
                 for (VirtualFile file : references.getSecond()) {
                     if (!Arrays.asList(openedFiles).contains(file)) {
                         toClose.add(file);
-                        try {
-                            Thread.sleep(50);
-                        } catch (InterruptedException e) {
-                            LOG.warn(e);
-                        }
                     }
                 }
-                Position servPos = DocumentUtils.offsetToLSPPos(editor, offset);
-                RenameParams params = new RenameParams(identifier, servPos, renameTo);
-                CompletableFuture<WorkspaceEdit> request = wrapper.getRequestManager().rename(params);
-                if (request != null) {
-                    request.thenAccept(res -> {
-                        boolean isApplied = WorkspaceEditHandler.applyEdit(res, "Rename to " + renameTo, toClose);
-                        LSPRenameProcessor.clearEditors();
-                        if (!isApplied) {
-                            for (VirtualFile file : toClose) {
-                                writeAction(() -> {
-                                    FileEditorManager.getInstance(project).closeFile(file);
-                                });
-                            }
+            }
+            Position servPos = DocumentUtils.offsetToLSPPos(editor, offset);
+            RenameParams params = new RenameParams(identifier, servPos, renameTo);
+            CompletableFuture<WorkspaceEdit> request = wrapper.getRequestManager().rename(params);
+            if (request != null) {
+                request.thenAccept(res -> {
+                    boolean isApplied = WorkspaceEditHandler.applyEdit(res, "Rename to " + renameTo, toClose);
+                    LSPRenameProcessor.clearEditors();
+                    if (!isApplied) {
+                        for (VirtualFile file : toClose) {
+                            invokeLater(() -> writeAction(
+                                    () -> FileEditorManager.getInstance(project).closeFile(file)));
                         }
-                    });
-                }
-            });
+                    }
+                });
+            }
         });
     }
 
@@ -847,7 +795,7 @@ public class EditorEventManager {
             LogicalPosition caretPos = editor.getCaretModel().getLogicalPosition();
             Point pointPos = editor.logicalPositionToXY(caretPos);
             long currentTime = System.nanoTime();
-            pool(() -> requestAndShowDoc(caretPos, pointPos));
+            wrapper.pool(() -> requestAndShowDoc(caretPos, pointPos));
             predTime = currentTime;
         } else {
             LOG.warn("Not same editor!");
@@ -866,42 +814,32 @@ public class EditorEventManager {
         if (request == null) {
             return;
         }
-        try {
-            Hover hover = request.get(getTimeout(HOVER), TimeUnit.MILLISECONDS);
-            wrapper.notifySuccess(HOVER);
+        Hover hover = wrapper.getRequestExecutor().waitFor(request, HOVER);
+        if (hover == null) {
+            LOG.debug(String.format("Hover is null for file %s and pos (%d;%d)", identifier.getUri(),
+                    serverPos.getLine(), serverPos.getCharacter()));
+            return;
+        }
 
-            if (hover == null) {
-                LOG.debug(String.format("Hover is null for file %s and pos (%d;%d)", identifier.getUri(),
-                        serverPos.getLine(), serverPos.getCharacter()));
-                return;
-            }
+        String string = HoverHandler.getHoverString(hover);
+        if (StringUtils.isEmpty(string)) {
+            LOG.warn(String.format("Hover string returned is empty for file %s and pos (%d;%d)",
+                    identifier.getUri(), serverPos.getLine(), serverPos.getCharacter()));
+            return;
+        }
 
-            String string = HoverHandler.getHoverString(hover);
-            if (StringUtils.isEmpty(string)) {
-                LOG.warn(String.format("Hover string returned is empty for file %s and pos (%d;%d)",
-                        identifier.getUri(), serverPos.getLine(), serverPos.getCharacter()));
-                return;
-            }
-
-            if (getIsCtrlDown()) {
-                invokeLater(() -> {
-                    if (!editor.isDisposed()) {
-                        currentHint = createAndShowEditorHint(editor, string, point, HintManager.HIDE_BY_OTHER_HINT);
-                    }
-                });
-            } else {
-                invokeLater(() -> {
-                    if (!editor.isDisposed()) {
-                        currentHint = createAndShowEditorHint(editor, string, point);
-                    }
-                });
-            }
-        } catch (TimeoutException e) {
-            LOG.warn(e);
-            wrapper.notifyFailure(HOVER);
-        } catch (InterruptedException | JsonRpcException | ExecutionException e) {
-            LOG.warn(e);
-            wrapper.crashed(e);
+        if (getIsCtrlDown()) {
+            invokeLater(() -> {
+                if (!editor.isDisposed()) {
+                    currentHint = createAndShowEditorHint(editor, string, point, HintManager.HIDE_BY_OTHER_HINT);
+                }
+            });
+        } else {
+            invokeLater(() -> {
+                if (!editor.isDisposed()) {
+                    currentHint = createAndShowEditorHint(editor, string, point);
+                }
+            });
         }
     }
 
@@ -916,41 +854,27 @@ public class EditorEventManager {
         List<LookupElement> lookupItems = new ArrayList<>();
         CompletableFuture<Either<List<CompletionItem>, CompletionList>> request = wrapper.getRequestManager()
                 .completion(new CompletionParams(identifier, pos));
-        if (request == null) {
+        Either<List<CompletionItem>, CompletionList> res =
+                wrapper.getRequestExecutor().waitFor(request, COMPLETION);
+        if (res == null) {
             return lookupItems;
         }
-
-        try {
-            Either<List<CompletionItem>, CompletionList> res =
-                    request.get(getTimeout(COMPLETION), TimeUnit.MILLISECONDS);
-            wrapper.notifySuccess(COMPLETION);
-            if (res == null) {
-                return lookupItems;
-            }
-            if (res.getLeft() != null) {
-                for (CompletionItem item : res.getLeft()) {
-                    LookupElement lookupElement = createLookupItem(item);
-                    if (lookupElement != null) {
-                        lookupItems.add(lookupElement);
-                    }
-                }
-            } else if (res.getRight() != null) {
-                for (CompletionItem item : res.getRight().getItems()) {
-                    LookupElement lookupElement = createLookupItem(item);
-                    if (lookupElement != null) {
-                        lookupItems.add(lookupElement);
-                    }
+        if (res.getLeft() != null) {
+            for (CompletionItem item : res.getLeft()) {
+                LookupElement lookupElement = createLookupItem(item);
+                if (lookupElement != null) {
+                    lookupItems.add(lookupElement);
                 }
             }
-        } catch (TimeoutException | InterruptedException e) {
-            LOG.warn(e);
-            wrapper.notifyFailure(COMPLETION);
-        } catch (JsonRpcException | ExecutionException e) {
-            LOG.warn(e);
-            wrapper.crashed(e);
-        } finally {
-            return lookupItems;
+        } else if (res.getRight() != null) {
+            for (CompletionItem item : res.getRight().getItems()) {
+                LookupElement lookupElement = createLookupItem(item);
+                if (lookupElement != null) {
+                    lookupItems.add(lookupElement);
+                }
+            }
         }
+        return lookupItems;
     }
 
     /**
@@ -1322,7 +1246,7 @@ public class EditorEventManager {
      * @param commands The commands to execute
      */
     public void executeCommands(List<Command> commands) {
-        pool(() -> {
+        wrapper.pool(() -> {
             if (editor.isDisposed()) {
                 return;
             }
@@ -1331,18 +1255,8 @@ public class EditorEventManager {
                 params.setArguments(c.getArguments());
                 params.setCommand(c.getCommand());
                 return wrapper.getRequestManager().executeCommand(params);
-            }).filter(Objects::nonNull).forEach(f -> {
-                try {
-                    f.get(getTimeout(EXECUTE_COMMAND), TimeUnit.MILLISECONDS);
-                    wrapper.notifySuccess(EXECUTE_COMMAND);
-                } catch (TimeoutException te) {
-                    LOG.warn(te);
-                    wrapper.notifyFailure(EXECUTE_COMMAND);
-                } catch (JsonRpcException | ExecutionException | InterruptedException e) {
-                    LOG.warn(e);
-                    wrapper.crashed(e);
-                }
-            });
+            }).filter(Objects::nonNull).forEach(f ->
+                    wrapper.getRequestExecutor().waitFor(f, EXECUTE_COMMAND));
         });
     }
 
@@ -1376,7 +1290,7 @@ public class EditorEventManager {
      * Notifies the server that the corresponding document has been closed.
      */
     public void documentClosed() {
-        pool(() -> {
+        wrapper.pool(() -> {
             if (this.isOpen) {
                 isOpen = false;
 
@@ -1389,7 +1303,7 @@ public class EditorEventManager {
     }
 
     public void documentOpened() {
-        pool(() -> {
+        wrapper.pool(() -> {
             if (editor.isDisposed()) {
                 return;
             }
@@ -1419,7 +1333,7 @@ public class EditorEventManager {
      * Notifies the server that the corresponding document has been saved.
      */
     public void documentSaved() {
-        pool(() -> {
+        wrapper.pool(() -> {
             if (!editor.isDisposed()) {
                 DidSaveTextDocumentParams params = new DidSaveTextDocumentParams(
                         identifier, editor.getDocument().getText());
@@ -1436,7 +1350,7 @@ public class EditorEventManager {
         if (wrapper.isWillSaveWaitUntil() && !needSave) {
             willSaveWaitUntil();
         } else {
-            pool(() -> {
+            wrapper.pool(() -> {
                 if (!editor.isDisposed()) {
                     wrapper.getRequestManager().willSave(
                             new WillSaveTextDocumentParams(
@@ -1452,7 +1366,7 @@ public class EditorEventManager {
      */
     private void willSaveWaitUntil() {
         if (wrapper.isWillSaveWaitUntil()) {
-            pool(() -> {
+            wrapper.pool(() -> {
                 if (editor.isDisposed()) {
                     return;
                 }
@@ -1460,26 +1374,13 @@ public class EditorEventManager {
                         TextDocumentSaveReason.Manual);
                 CompletableFuture<List<TextEdit>> future = wrapper.getRequestManager().willSaveWaitUntil(params);
                 if (future != null) {
-                    try {
-                        List<TextEdit> edits = future.get(getTimeout(WILLSAVE), TimeUnit.MILLISECONDS);
-                        wrapper.notifySuccess(WILLSAVE);
-                        if (edits != null) {
-                            invokeLater(() -> applyEdit(toEither(edits), "WaitUntil edits", false));
-                        }
-                    } catch (TimeoutException e) {
-                        LOG.warn(e);
-                        wrapper.notifyFailure(WILLSAVE);
-                    } catch (JsonRpcException | ExecutionException | InterruptedException e) {
-                        LOG.warn(e);
-                        wrapper.crashed(e);
-                    } finally {
-                        needSave = true;
-                        saveDocument();
+                    List<TextEdit> edits = wrapper.getRequestExecutor().waitFor(future, WILLSAVE);
+                    if (edits != null) {
+                        invokeLater(() -> applyEdit(toEither(edits), "WaitUntil edits", false));
                     }
-                } else {
-                    needSave = true;
-                    saveDocument();
                 }
+                needSave = true;
+                saveDocument();
             });
         } else {
             LOG.error("Server doesn't support WillSaveWaitUntil");
@@ -1496,43 +1397,49 @@ public class EditorEventManager {
             return;
         }
 
-        createCtrlRange(DocumentUtils.logicalToLSPPos(editor.xyToLogicalPosition(e.getMouseEvent().getPoint()), editor),
-                null);
-        final CtrlRangeMarker ctrlRange = getCtrlRange();
-
-        if (ctrlRange == null) {
-            int offset = editor.logicalPositionToOffset(editor.xyToLogicalPosition(e.getMouseEvent().getPoint()));
-            LSPReferencesAction referencesAction = (LSPReferencesAction) ActionManager.getInstance()
-                    .getAction("LSPFindUsages");
-            if (referencesAction != null) {
-                referencesAction.forManagerAndOffset(this, offset);
-            }
-            return;
-        }
-
-        Location loc = ctrlRange.location;
-        invokeLater(() -> {
-            if (editor.isDisposed()) {
-                return;
-            }
-
-            int offset = editor.logicalPositionToOffset(editor.xyToLogicalPosition(e.getMouseEvent().getPoint()));
-            String locUri = FileUtils.sanitizeURI(loc.getUri());
-
-            if (identifier.getUri().equals(locUri)
-                    && offset >= DocumentUtils.lspPosToOffset(editor, loc.getRange().getStart())
-                    && offset <= DocumentUtils.lspPosToOffset(editor, loc.getRange().getEnd())) {
-                LSPReferencesAction referencesAction = (LSPReferencesAction) ActionManager.getInstance()
-                        .getAction("LSPFindUsages");
-                if (referencesAction != null) {
-                    referencesAction.forManagerAndOffset(this, offset);
+        Position position = DocumentUtils.logicalToLSPPos(
+                editor.xyToLogicalPosition(e.getMouseEvent().getPoint()), editor);
+        wrapper.pool(() -> {
+            // Resolves the definition off the EDT; range markup and navigation run on the EDT afterwards.
+            Location definitionLocation = requestDefinition(position);
+            invokeLater(() -> {
+                if (editor.isDisposed()) {
+                    return;
                 }
-            } else {
-                gotoLocation(loc);
-            }
 
-            ctrlRange.dispose();
-            setCtrlRange(null);
+                createCtrlRange(position, null, definitionLocation);
+                final CtrlRangeMarker ctrlRange = getCtrlRange();
+
+                if (ctrlRange == null) {
+                    int offset = editor.logicalPositionToOffset(
+                            editor.xyToLogicalPosition(e.getMouseEvent().getPoint()));
+                    LSPReferencesAction referencesAction = (LSPReferencesAction) ActionManager.getInstance()
+                            .getAction("LSPFindUsages");
+                    if (referencesAction != null) {
+                        referencesAction.forManagerAndOffset(this, offset);
+                    }
+                    return;
+                }
+
+                Location loc = ctrlRange.location;
+                int offset = editor.logicalPositionToOffset(editor.xyToLogicalPosition(e.getMouseEvent().getPoint()));
+                String locUri = FileUtils.sanitizeURI(loc.getUri());
+
+                if (identifier.getUri().equals(locUri)
+                        && offset >= DocumentUtils.lspPosToOffset(editor, loc.getRange().getStart())
+                        && offset <= DocumentUtils.lspPosToOffset(editor, loc.getRange().getEnd())) {
+                    LSPReferencesAction referencesAction = (LSPReferencesAction) ActionManager.getInstance()
+                            .getAction("LSPFindUsages");
+                    if (referencesAction != null) {
+                        referencesAction.forManagerAndOffset(this, offset);
+                    }
+                } else {
+                    gotoLocation(loc);
+                }
+
+                ctrlRange.dispose();
+                setCtrlRange(null);
+            });
         });
     }
 
@@ -1564,25 +1471,45 @@ public class EditorEventManager {
     }
 
     public void requestAndShowCodeActions() {
-        invokeLater(() -> {
+        wrapper.pool(() -> {
             if (editor.isDisposed()) {
                 return;
             }
-            if (annotations == null) {
-                annotations = new ArrayList<>();
-            }
 
-            // sends code action request.
-            int caretPos = editor.getCaretModel().getCurrentCaret().getOffset();
+            // Sends the code action request and resolves incomplete code actions while off the EDT;
+            // only the annotation bookkeeping runs on the EDT.
+            int caretPos = computableReadAction(() -> editor.getCaretModel().getCurrentCaret().getOffset());
             List<Either<Command, CodeAction>> codeActionResp = codeAction(caretPos);
             if (codeActionResp == null || codeActionResp.isEmpty()) {
                 return;
             }
-
-            codeActionResp.forEach(element -> {
+            List<Either<Command, CodeAction>> codeActions = new ArrayList<>();
+            for (Either<Command, CodeAction> element : codeActionResp) {
                 if (element == null) {
-                    return;
+                    continue;
                 }
+                if (element.isRight() && element.getRight().getEdit() == null) {
+                    CodeAction resolved = resolvedCodeAction(element.getRight());
+                    if (resolved != null && resolved.getEdit() != null) {
+                        codeActions.add(Either.forRight(resolved));
+                        continue;
+                    }
+                }
+                codeActions.add(element);
+            }
+            invokeLater(() -> showCodeActions(caretPos, codeActions));
+        });
+    }
+
+    private void showCodeActions(int caretPos, List<Either<Command, CodeAction>> codeActions) {
+        if (editor.isDisposed()) {
+            return;
+        }
+        if (annotations == null) {
+            annotations = new ArrayList<>();
+        }
+
+        codeActions.forEach(element -> {
                 if (element.isLeft()) {
                     Command command = element.getLeft();
                     Annotation annotWithCodeAction = null;
@@ -1606,12 +1533,6 @@ public class EditorEventManager {
                     }
                 } else if (element.isRight()) {
                     CodeAction codeAction = element.getRight();
-                    if (codeAction.getEdit() == null) {
-                        CodeAction resolvedCodeAction = resolvedCodeAction(codeAction);
-                        if (resolvedCodeAction != null && resolvedCodeAction.getEdit() != null) {
-                            codeAction = resolvedCodeAction;
-                        }
-                    }
                     List<Diagnostic> diagnosticContext = codeAction.getDiagnostics();
                     Annotation annotWithCodeAction = null;
                     for (Annotation annotation : annotations) {
@@ -1662,13 +1583,12 @@ public class EditorEventManager {
                         codeActionSyncRequired = true;
                     }
                 }
-            });
-            // If code actions are updated, forcefully triggers the inspection tool.
-            if (codeActionSyncRequired) {
-                // double-delay the update to ensure that the code analyzer finishes.
-                invokeLater(this::updateErrorAnnotations);
-            }
         });
+        // If code actions are updated, forcefully triggers the inspection tool.
+        if (codeActionSyncRequired) {
+            // double-delay the update to ensure that the code analyzer finishes.
+            invokeLater(this::updateErrorAnnotations);
+        }
     }
 
     /**

--- a/src/main/java/org/wso2/lsp4intellij/listeners/LSPCaretListenerImpl.java
+++ b/src/main/java/org/wso2/lsp4intellij/listeners/LSPCaretListenerImpl.java
@@ -18,9 +18,9 @@ package org.wso2.lsp4intellij.listeners;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.event.CaretEvent;
 import com.intellij.openapi.editor.event.CaretListener;
+import com.intellij.util.concurrency.AppExecutorUtil;
 import org.jetbrains.annotations.NotNull;
 
-import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -29,12 +29,13 @@ public class LSPCaretListenerImpl extends LSPListener implements CaretListener {
 
     private static final Logger LOG = Logger.getInstance(LSPCaretListenerImpl.class);
 
+    // The shared application pool is used so that no thread has to be created (and disposed) per editor.
     private final ScheduledExecutorService scheduler;
     private ScheduledFuture<?> scheduledFuture;
     private static final long DEBOUNCE_INTERVAL_MS = 500;
 
     public LSPCaretListenerImpl() {
-        scheduler = Executors.newScheduledThreadPool(1);
+        scheduler = AppExecutorUtil.getAppScheduledExecutorService();
         scheduledFuture = null;
     }
 

--- a/src/main/java/org/wso2/lsp4intellij/requests/RequestExecutor.java
+++ b/src/main/java/org/wso2/lsp4intellij/requests/RequestExecutor.java
@@ -61,7 +61,13 @@ public class RequestExecutor {
             LOG.warn(e);
             wrapper.notifyFailure(timeoutType);
             return null;
-        } catch (InterruptedException | JsonRpcException | ExecutionException e) {
+        } catch (InterruptedException e) {
+            // The dispatcher is interrupted when the wrapper is disposed; routing this to the crash
+            // handler could restart the server while it is being torn down.
+            LOG.warn(e);
+            Thread.currentThread().interrupt();
+            return null;
+        } catch (JsonRpcException | ExecutionException e) {
             LOG.warn(e);
             wrapper.crashed(e);
             return null;

--- a/src/main/java/org/wso2/lsp4intellij/requests/RequestExecutor.java
+++ b/src/main/java/org/wso2/lsp4intellij/requests/RequestExecutor.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.requests;
+
+import com.intellij.openapi.diagnostic.Logger;
+import org.eclipse.lsp4j.jsonrpc.JsonRpcException;
+import org.jetbrains.annotations.Nullable;
+import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import static org.wso2.lsp4intellij.requests.Timeout.getTimeout;
+
+/**
+ * Executes blocking waits on language server request futures with a uniform policy: the timeout configured
+ * for the request type is enforced, the server status widget is notified of the result, and protocol errors
+ * are routed to the wrapper's crash handler.
+ */
+public class RequestExecutor {
+
+    private static final Logger LOG = Logger.getInstance(RequestExecutor.class);
+
+    private final LanguageServerWrapper wrapper;
+
+    public RequestExecutor(LanguageServerWrapper wrapper) {
+        this.wrapper = wrapper;
+    }
+
+    /**
+     * Waits for the given request future using the timeout configured for the given timeout type.
+     * Must not be called on the event dispatch thread.
+     *
+     * @return the request result, or null if the future is null, the request timed out, or the request failed
+     */
+    @Nullable
+    public <T> T waitFor(@Nullable CompletableFuture<T> future, Timeouts timeoutType) {
+        if (future == null) {
+            return null;
+        }
+        try {
+            T result = future.get(getTimeout(timeoutType), TimeUnit.MILLISECONDS);
+            wrapper.notifySuccess(timeoutType);
+            return result;
+        } catch (TimeoutException e) {
+            LOG.warn(e);
+            wrapper.notifyFailure(timeoutType);
+            return null;
+        } catch (InterruptedException | JsonRpcException | ExecutionException e) {
+            LOG.warn(e);
+            wrapper.crashed(e);
+            return null;
+        }
+    }
+}

--- a/src/main/java/org/wso2/lsp4intellij/utils/ApplicationUtils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/ApplicationUtils.java
@@ -44,6 +44,10 @@ public class ApplicationUtils {
         ApplicationManager.getApplication().invokeLater(runnable);
     }
 
+    public static void invokeAndWait(Runnable runnable) {
+        ApplicationManager.getApplication().invokeAndWait(runnable);
+    }
+
     public static void pool(Runnable runnable) {
         EXECUTOR_SERVICE.submit(runnable);
     }

--- a/src/main/java/org/wso2/lsp4intellij/utils/Utils.java
+++ b/src/main/java/org/wso2/lsp4intellij/utils/Utils.java
@@ -33,7 +33,14 @@ public class Utils {
      */
     public String arrayToString(Object[] arr, String sep) {
         sep = (sep != null) ? sep : "";
-        return String.join(sep, Arrays.toString(arr));
+        StringBuilder builder = new StringBuilder();
+        for (int i = 0; i < arr.length; i++) {
+            if (i > 0) {
+                builder.append(sep);
+            }
+            builder.append(arr[i]);
+        }
+        return builder.toString();
     }
 
     /**
@@ -89,8 +96,8 @@ public class Utils {
                     wasEscaped = !wasEscaped;
                     curStr.append('\\');
                     break;
-                case 'c':
-                    curStr.append('c');
+                default:
+                    curStr.append(str.charAt(i));
                     wasEscaped = false;
                     break;
                 }

--- a/src/test/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/DefaultRequestManagerTest.java
+++ b/src/test/java/org/wso2/lsp4intellij/client/languageserver/requestmanager/DefaultRequestManagerTest.java
@@ -338,14 +338,14 @@ public class DefaultRequestManagerTest {
     // ── didClose ──────────────────────────────────────────────────────────────
 
     /**
-     * Verifies that {@link DefaultRequestManager#didClose(DidCloseTextDocumentParams)} skips in
-     * sync-kind mode because textDocumentOptions is null, making openClose default to false.
+     * Verifies that {@link DefaultRequestManager#didClose(DidCloseTextDocumentParams)} delegates in
+     * sync-kind mode: a bare sync kind implies open/close notifications, consistent with didOpen.
      */
     @Test
-    public void didCloseSkipsInSyncKindMode() {
+    public void didCloseDelegatesInSyncKindMode() {
         when(wrapper.getStatus()).thenReturn(ServerStatus.INITIALIZED);
         managerWithSyncKind(TextDocumentSyncKind.Incremental).didClose(new DidCloseTextDocumentParams());
-        verify(textDocumentService, never()).didClose(any());
+        verify(textDocumentService).didClose(any());
     }
 
     /**

--- a/src/test/java/org/wso2/lsp4intellij/integration/LspServerIntegrationTest.java
+++ b/src/test/java/org/wso2/lsp4intellij/integration/LspServerIntegrationTest.java
@@ -1,0 +1,304 @@
+/*
+ * Copyright (c) 2026, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.integration;
+
+import com.intellij.openapi.command.WriteCommandAction;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.testFramework.EdtTestUtil;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import org.eclipse.lsp4j.DidChangeConfigurationParams;
+import org.eclipse.lsp4j.DidChangeTextDocumentParams;
+import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
+import org.eclipse.lsp4j.DidCloseTextDocumentParams;
+import org.eclipse.lsp4j.DidOpenTextDocumentParams;
+import org.eclipse.lsp4j.DidSaveTextDocumentParams;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.InitializeResult;
+import org.eclipse.lsp4j.ServerCapabilities;
+import org.eclipse.lsp4j.TextDocumentSyncKind;
+import org.eclipse.lsp4j.jsonrpc.Launcher;
+import org.eclipse.lsp4j.launch.LSPLauncher;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.eclipse.lsp4j.services.TextDocumentService;
+import org.eclipse.lsp4j.services.WorkspaceService;
+import org.wso2.lsp4intellij.IntellijLanguageClient;
+import org.wso2.lsp4intellij.client.connection.StreamConnectionProvider;
+import org.wso2.lsp4intellij.client.languageserver.ServerStatus;
+import org.wso2.lsp4intellij.client.languageserver.serverdefinition.LanguageServerDefinition;
+import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
+import org.wso2.lsp4intellij.utils.FileUtils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.PipedInputStream;
+import java.io.PipedOutputStream;
+import java.util.HashSet;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.function.BooleanSupplier;
+
+/**
+ * End-to-end tests which run the library against an in-process stub language server connected
+ * over piped streams. The tests drive the same entry points a consuming plugin uses
+ * ({@code addServerDefinition}, {@code editorOpened}, {@code editorClosed}) and assert on the
+ * protocol messages the stub server receives.
+ */
+public class LspServerIntegrationTest extends BasePlatformTestCase {
+
+    private static final int TIMEOUT_SECONDS = 30;
+    private static final String FILE_CONTENT = "hello lsp";
+
+    private StubLanguageServer stubServer;
+
+    @Override
+    protected boolean runInDispatchThread() {
+        // The library completes connections on background threads; the test thread must be able
+        // to block on latches while the event dispatch thread stays free.
+        return false;
+    }
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        stubServer = new StubLanguageServer();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        try {
+            String projectUri = FileUtils.projectToUri(getProject());
+            if (projectUri != null) {
+                for (LanguageServerWrapper wrapper
+                        : new HashSet<>(IntellijLanguageClient.getAllServerWrappersFor(projectUri))) {
+                    wrapper.stop(true);
+                    IntellijLanguageClient.removeWrapper(wrapper);
+                }
+            }
+        } finally {
+            super.tearDown();
+        }
+    }
+
+    public void testServerInitializesAndReceivesDidOpen() throws Exception {
+        Editor editor = openEditorFor("stuba");
+
+        assertTrue("initialize was not received", stubServer.initialized.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        assertTrue("didOpen was not received", stubServer.didOpen.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        assertEquals(FILE_CONTENT, stubServer.openParams.getTextDocument().getText());
+
+        LanguageServerWrapper wrapper = LanguageServerWrapper.forEditor(editor);
+        assertNotNull(wrapper);
+        waitFor("server status must become INITIALIZED",
+                () -> wrapper.getStatus() == ServerStatus.INITIALIZED);
+    }
+
+    public void testDocumentEditSendsDidChange() throws Exception {
+        Editor editor = openEditorFor("stubb");
+        assertTrue("didOpen was not received", stubServer.didOpen.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+
+        EdtTestUtil.runInEdtAndWait(() -> WriteCommandAction.runWriteCommandAction(getProject(),
+                () -> editor.getDocument().insertString(0, "x")));
+
+        assertTrue("didChange was not received", stubServer.didChange.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        // The stub server declares full document sync, so the change event carries the whole text.
+        assertEquals("x" + FILE_CONTENT, stubServer.changeParams.getContentChanges().get(0).getText());
+        assertTrue(stubServer.changeParams.getTextDocument().getVersion() >= 1);
+    }
+
+    public void testEditorCloseSendsDidCloseAndStopsServer() throws Exception {
+        Editor editor = openEditorFor("stubc");
+        assertTrue("didOpen was not received", stubServer.didOpen.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+
+        LanguageServerWrapper wrapper = LanguageServerWrapper.forEditor(editor);
+        assertNotNull(wrapper);
+
+        IntellijLanguageClient.editorClosed(editor);
+
+        assertTrue("didClose was not received", stubServer.didClose.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        assertTrue("shutdown was not received", stubServer.shutdown.await(TIMEOUT_SECONDS, TimeUnit.SECONDS));
+        waitFor("server status must become STOPPED", () -> wrapper.getStatus() == ServerStatus.STOPPED);
+    }
+
+    /**
+     * Registers a stub server definition for the given extension, opens an editor on a matching
+     * file, and routes the open event through the library entry point.
+     */
+    private Editor openEditorFor(String ext) {
+        IntellijLanguageClient.addServerDefinition(new StubServerDefinition(ext, stubServer), getProject());
+        EdtTestUtil.runInEdtAndWait(() -> myFixture.configureByText("test." + ext, FILE_CONTENT));
+        Editor editor = myFixture.getEditor();
+        IntellijLanguageClient.editorOpened(editor);
+        return editor;
+    }
+
+    private void waitFor(String description, BooleanSupplier condition) throws InterruptedException {
+        long deadline = System.currentTimeMillis() + TimeUnit.SECONDS.toMillis(TIMEOUT_SECONDS);
+        while (!condition.getAsBoolean()) {
+            if (System.currentTimeMillis() > deadline) {
+                fail(description);
+            }
+            Thread.sleep(50);
+        }
+    }
+
+    /**
+     * A server definition which connects to the in-process stub server instead of spawning a process.
+     */
+    private static class StubServerDefinition extends LanguageServerDefinition {
+
+        private final LanguageServer server;
+
+        StubServerDefinition(String ext, LanguageServer server) {
+            this.ext = ext;
+            this.server = server;
+        }
+
+        @Override
+        public StreamConnectionProvider createConnectionProvider(String workingDir) {
+            return new StubConnectionProvider(server);
+        }
+    }
+
+    /**
+     * Connects the client side of the library to an in-process lsp4j server over piped streams.
+     */
+    private static class StubConnectionProvider implements StreamConnectionProvider {
+
+        private final LanguageServer server;
+        private InputStream clientInput;
+        private OutputStream clientOutput;
+        private Future<Void> listening;
+
+        StubConnectionProvider(LanguageServer server) {
+            this.server = server;
+        }
+
+        @Override
+        public void start() throws IOException {
+            PipedInputStream serverInput = new PipedInputStream(65536);
+            PipedOutputStream clientToServer = new PipedOutputStream(serverInput);
+            PipedInputStream serverToClient = new PipedInputStream(65536);
+            PipedOutputStream serverOutput = new PipedOutputStream(serverToClient);
+
+            Launcher<LanguageClient> launcher = LSPLauncher.createServerLauncher(server, serverInput, serverOutput);
+            listening = launcher.startListening();
+            this.clientInput = serverToClient;
+            this.clientOutput = clientToServer;
+        }
+
+        @Override
+        public InputStream getInputStream() {
+            return clientInput;
+        }
+
+        @Override
+        public OutputStream getOutputStream() {
+            return clientOutput;
+        }
+
+        @Override
+        public void stop() {
+            if (listening != null) {
+                listening.cancel(true);
+            }
+            try {
+                if (clientInput != null) {
+                    clientInput.close();
+                }
+                if (clientOutput != null) {
+                    clientOutput.close();
+                }
+            } catch (IOException ignored) {
+                // The pipes are in-memory; nothing to clean up on failure.
+            }
+        }
+    }
+
+    /**
+     * A minimal language server which records the notifications it receives.
+     */
+    private static class StubLanguageServer implements LanguageServer {
+
+        final CountDownLatch initialized = new CountDownLatch(1);
+        final CountDownLatch didOpen = new CountDownLatch(1);
+        final CountDownLatch didChange = new CountDownLatch(1);
+        final CountDownLatch didClose = new CountDownLatch(1);
+        final CountDownLatch shutdown = new CountDownLatch(1);
+        volatile DidOpenTextDocumentParams openParams;
+        volatile DidChangeTextDocumentParams changeParams;
+
+        @Override
+        public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
+            ServerCapabilities capabilities = new ServerCapabilities();
+            capabilities.setTextDocumentSync(TextDocumentSyncKind.Full);
+            initialized.countDown();
+            return CompletableFuture.completedFuture(new InitializeResult(capabilities));
+        }
+
+        @Override
+        public CompletableFuture<Object> shutdown() {
+            shutdown.countDown();
+            return CompletableFuture.completedFuture(new Object());
+        }
+
+        @Override
+        public void exit() {
+        }
+
+        @Override
+        public TextDocumentService getTextDocumentService() {
+            return new TextDocumentService() {
+                @Override
+                public void didOpen(DidOpenTextDocumentParams params) {
+                    openParams = params;
+                    didOpen.countDown();
+                }
+
+                @Override
+                public void didChange(DidChangeTextDocumentParams params) {
+                    changeParams = params;
+                    didChange.countDown();
+                }
+
+                @Override
+                public void didClose(DidCloseTextDocumentParams params) {
+                    didClose.countDown();
+                }
+
+                @Override
+                public void didSave(DidSaveTextDocumentParams params) {
+                }
+            };
+        }
+
+        @Override
+        public WorkspaceService getWorkspaceService() {
+            return new WorkspaceService() {
+                @Override
+                public void didChangeConfiguration(DidChangeConfigurationParams params) {
+                }
+
+                @Override
+                public void didChangeWatchedFiles(DidChangeWatchedFilesParams params) {
+                }
+            };
+        }
+    }
+}

--- a/src/test/java/org/wso2/lsp4intellij/utils/UtilsTest.java
+++ b/src/test/java/org/wso2/lsp4intellij/utils/UtilsTest.java
@@ -82,7 +82,7 @@ public class UtilsTest {
      */
     @Test
     public void testParseArgsC() {
-        Assert.assertArrayEquals(new String[]{"c"}, Utils.parseArgs(new String[]{"c"}));
+        Assert.assertArrayEquals(new String[]{"abc"}, Utils.parseArgs(new String[]{"abc"}));
     }
 
     /**
@@ -123,8 +123,7 @@ public class UtilsTest {
      */
     @Test
     public void testParseArgsSplitsOnUnquotedSpace() {
-        // parseArgs only knows about a small alphabet (', ", space, \, c). Use c-tokens.
-        Assert.assertArrayEquals(new String[]{"c", "c"}, Utils.parseArgs(new String[]{"c c"}));
+        Assert.assertArrayEquals(new String[]{"foo", "bar"}, Utils.parseArgs(new String[]{"foo bar"}));
     }
 
     /**
@@ -169,7 +168,17 @@ public class UtilsTest {
     @Test
     public void testArrayToStringDefaultSep() {
         Utils utils = new Utils();
-        Assert.assertEquals("[a, b]", utils.arrayToString(new String[]{"a", "b"}, null));
+        Assert.assertEquals("ab", utils.arrayToString(new String[]{"a", "b"}, null));
+    }
+
+    /**
+     * Verifies that {@link Utils#arrayToString(Object[], String)} joins elements with the
+     * supplied separator.
+     */
+    @Test
+    public void testArrayToStringWithSep() {
+        Utils utils = new Utils();
+        Assert.assertEquals("a,b", utils.arrayToString(new String[]{"a", "b"}, ","));
     }
 
     /**
@@ -178,7 +187,7 @@ public class UtilsTest {
     @Test
     public void testArrayToStringEmpty() {
         Utils utils = new Utils();
-        Assert.assertEquals("[]", utils.arrayToString(new Object[0], ","));
+        Assert.assertEquals("", utils.arrayToString(new Object[0], ","));
     }
 
     /**


### PR DESCRIPTION
## Purpose

Fixes UI freezes and cross-server stalls caused by the current threading model, and fixes a set of concurrency and protocol bugs. Adds an integration test harness that runs the library against an in-process stub language server.

## Problems addressed

- All async LSP work for every server of every project was serialized on one global single-threaded executor (`ApplicationUtils.pool()`), so one slow server stalled hover, completion, and document sync for all servers.
- Several request paths performed blocking `Future.get()` calls on the EDT: code action requests from the caret listener (up to 2 s), rename (blocking references call plus a `Thread.sleep(50)` loop inside `invokeLater`), and ctrl-click navigation.
- The request timeout/error-handling block was duplicated nine times in `EditorEventManager`.
- Thread leaks: the lsp4j launcher's cached thread pool was never shut down, and each caret listener created its own scheduler thread that was never shut down.
- `didClose` was never delivered when a server declares text document sync as a bare `TextDocumentSyncKind`: the capability guard required explicit `openClose=true` (inconsistent with `didOpen` and the LSP spec), and on last-editor close the server was shut down before the queued `didClose` was sent.
- Data races: unsynchronized `HashSet`/`HashMap` state in `LanguageServerWrapper` and `DocumentEventManager` mutated from the EDT, the pool, and lsp4j threads; non-atomic `crashCount` and document version counters.

## Changes

- Each `LanguageServerWrapper` now owns a named single-threaded dispatcher. Per-server work (requests, didOpen/didChange/didClose/didSave, connect/disconnect, restart) runs there, preserving per-server message order without cross-server contention. The dispatcher is shut down on `dispose()`; the launcher executor is shut down on `stop()`.
- New `RequestExecutor` centralizes the blocking-wait policy (timeout per request type, status widget notification, crash routing), replacing the nine duplicated try/catch blocks.
- Code action, rename, and ctrl-click definition requests now run off the EDT; only UI application (annotations, markup, navigation) runs on it. `references()` is callable from any thread; editor opening/closing is marshaled to the EDT.
- Caret listeners use the shared application scheduled executor instead of one thread per editor.
- `didClose` is sent in sync-kind mode (matching `didOpen`), and last-editor close defers server stop until the queued `didClose` is sent.
- Server process stop falls back to `destroyForcibly()` after a 5 s grace period.
- Shared wrapper/document state uses concurrent collections and atomic counters.
- Smaller fixes: NPE in `didChangeConfiguration` for projects without servers, `LSPPsiElement.textMatches` used reference equality, `Utils.arrayToString` joined the wrong value, `Utils.parseArgs` dropped ordinary characters.

## Testing

- New `LspServerIntegrationTest` (`BasePlatformTestCase` + in-process lsp4j stub server over piped streams) covers server initialize/didOpen on editor open, didChange with version increments on document edit, and didClose/shutdown on editor close. These tests caught the two `didClose` bugs fixed here.
- Full suite: 136 tests passing; checkstyle clean; no new SpotBugs finding categories.

## Behavior notes for reviewers

- `completion()` now treats `InterruptedException` as a crash (uniform policy) instead of a quiet failure notification; the other eight request sites already behaved this way.
- The find-usages action (`LSPReferencesAction`) still blocks on the EDT because it shows its popup synchronously; left for a follow-up.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
This PR improves stability and responsiveness of the LSP client by refactoring its concurrency model to use a per-`LanguageServerWrapper` single-threaded dispatcher, ensuring that a slow language server no longer blocks others. It also moves blocking LSP interactions off the editor event thread, centralizes request timeout and failure/crash handling via a new `RequestExecutor`, and updates event routing to consistently use the correct execution context.

The PR hardens server lifecycle and document synchronization behavior by fixing `didClose` handling for sync-kind servers, deferring shutdown until queued `didClose` notifications are delivered, and improving process termination with a grace period followed by forced shutdown. It further addresses concurrency and resource management concerns by making wrapper/document state thread-safe (concurrent collections and atomic counters), ensuring serialized shutdown (`stop` is synchronized), and preventing leaked or late-dispatched tasks after disposal.

Additional changes include correcting a PSI text comparison bug, refining scheduling for caret/debounced interactions and reference lookup, improving robustness for process and argument/utility parsing edge cases, and adding an in-process stub language server integration test that verifies initialize/open/change/close/shutdown flows end-to-end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->