### PR TITLE
Fix folding NPE and update setup guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ Here are some open-source projects that use `lsp4intellij` to integrate their la
 
 ## Quick Start
 
-The minimum integration is three pieces: add the dependency, register a language server in a preloading activity, and wire that activity into `plugin.xml`. Replace the command and file extension with your own.
+The minimum integration is three pieces: add the dependency, register a language server from a startup activity, and wire that activity into `plugin.xml`. Replace the command and file extension with your own.
 
 **`build.gradle`** — see [JitPack](https://jitpack.io/#ballerina-platform/lsp4intellij) for Maven and SBT snippets.
 
@@ -84,14 +84,16 @@ The minimum integration is three pieces: add the dependency, register a language
 implementation 'com.github.ballerina-platform:lsp4intellij:<version>'
 ```
 
-**Preloading activity**
+**Startup activity**
 
 ```java
-public class MyLspPreloader extends PreloadingActivity {
+public class MyLspStartup implements ProjectActivity {
+    @Nullable
     @Override
-    public void preload(@NotNull ProgressIndicator indicator) {
+    public Object execute(@NotNull Project project, @NotNull Continuation<? super Unit> continuation) {
         IntellijLanguageClient.addServerDefinition(
             new RawCommandServerDefinition("mylang", new String[]{"path/to/language-server"}));
+        return Unit.INSTANCE;
     }
 }
 ```
@@ -100,10 +102,11 @@ public class MyLspPreloader extends PreloadingActivity {
 
 ```xml
 <extensions defaultExtensionNs="com.intellij">
-    <preloadingActivity implementation="com.example.MyLspPreloader"
-                        id="com.example.MyLspPreloader"/>
+    <postStartupActivity implementation="com.example.MyLspStartup"/>
 </extensions>
 ```
+
+> **Note:** On IntelliJ 2024.3+, `PreloadingActivity` is no longer run, so register the server definition from a `ProjectActivity` wired to the `postStartupActivity` extension point.
 
 A green icon in the IDE's bottom-right confirms a successful connection.
 

--- a/docs/developer-guide.md
+++ b/docs/developer-guide.md
@@ -10,7 +10,7 @@ This guide walks through integrating `lsp4intellij` into your custom JetBrains p
 
 - [1. Add the `lsp4intellij` dependency](#1-add-the-lsp4intellij-dependency)
 - [2. Add a `plugin.xml` file](#2-add-a-pluginxml-file)
-- [3. Configure a preloading activity](#3-configure-a-preloading-activity)
+- [3. Configure a startup activity](#3-configure-a-startup-activity)
 - [4. Confirm the language server connection](#4-confirm-the-language-server-connection)
 - [Alternative ways to connect to a language server](#alternative-ways-to-connect-to-a-language-server)
   * [RawCommandServerDefinition](#rawcommandserverdefinition)
@@ -39,29 +39,32 @@ Supported build tools:
 
 Define the required configurations in your `plugin.xml` file. Copy the example from [resources/plugin.xml.example](../resources/plugin.xml.example), place it under `src/resources/META-INF`, and adjust it as needed.
 
-## 3. Configure a preloading activity
+## 3. Configure a startup activity
 
-Add a preloading activity to initialize and configure LSP support:
+Add a startup activity to initialize and configure LSP support. On IntelliJ 2024.3+, `PreloadingActivity` is no longer run, so implement `ProjectActivity` and register it through the `postStartupActivity` extension point:
 
 ```java
-public class BallerinaPreloadingActivity extends PreloadingActivity {
+public class BallerinaStartupActivity implements ProjectActivity {
+    @Nullable
     @Override
-    public void preload(ProgressIndicator indicator) {
+    public Object execute(@NotNull Project project, @NotNull Continuation<? super Unit> continuation) {
         IntellijLanguageClient.addServerDefinition(new RawCommandServerDefinition("bal", new String[]{"path/to/launcher-script.sh"}));
+        return Unit.INSTANCE;
     }
 }
 ```
 
-Update your `plugin.xml` to include the preloading activity:
+`addServerDefinition` registers the server application-wide and reconnects any editors that are already open, so running it once per project open is sufficient.
+
+Update your `plugin.xml` to include the startup activity:
 
 ```xml
 <extensions defaultExtensionNs="com.intellij">
-    <preloadingActivity implementation="io.ballerina.plugins.idea.preloading.BallerinaPreloadingActivity"
-                        id="io.ballerina.plugins.idea.preloading.BallerinaPreloadingActivity" />
+    <postStartupActivity implementation="io.ballerina.plugins.idea.preloading.BallerinaStartupActivity" />
 </extensions>
 ```
 
-> **Tip:** For other options instead of a preloading activity, see [IntelliJ Plugin initialization on startup](https://www.plugin-dev.com/intellij/general/plugin-initial-load/).
+> **Tip:** For other options instead of a startup activity, see [IntelliJ Plugin initialization on startup](https://www.plugin-dev.com/intellij/general/plugin-initial-load/).
 
 ## 4. Confirm the language server connection
 

--- a/resources/plugin.xml.example
+++ b/resources/plugin.xml.example
@@ -12,8 +12,9 @@ see also jetbrains documentation: https://plugins.jetbrains.com/docs/intellij/pl
     <depends>com.intellij.modules.platform</depends>
 
     <extensions defaultExtensionNs="com.intellij">
-        <!-- register a preloading activity. You need to init IntellijLanguageClient with your config, see readme -->
-        <preloadingActivity implementation="your.plugin.MyPreloadingActivity" id="your.plugin.MyPreloadingActivity"/>
+        <!-- register a startup activity. You need to init IntellijLanguageClient with your config, see readme.
+             On IntelliJ 2024.3+, PreloadingActivity is no longer run; use a ProjectActivity here instead. -->
+        <postStartupActivity implementation="your.plugin.MyStartupActivity"/>
 
         <!-- register intellijLanguageClient as a Service OR as a plugin component (see readme)... -->
         <applicationService serviceImplementation="org.wso2.lsp4intellij.IntellijLanguageClient"/>

--- a/src/main/java/org/wso2/lsp4intellij/contributors/LSPFoldingRangeProvider.java
+++ b/src/main/java/org/wso2/lsp4intellij/contributors/LSPFoldingRangeProvider.java
@@ -63,6 +63,12 @@ public class LSPFoldingRangeProvider extends CustomFoldingBuilder {
             wrapper = LanguageServerWrapper.forVirtualFile(psiFile.getVirtualFile(), root.getProject());
         }
 
+        // No initialized language server is connected for this file yet, so there is nothing to fold.
+        // getRequestManager() stays null until the server has started and initialized.
+        if (wrapper == null || wrapper.getRequestManager() == null) {
+            return;
+        }
+
         String url = root.getContainingFile().getVirtualFile().getUrl();
         TextDocumentIdentifier textDocumentIdentifier = new TextDocumentIdentifier(url);
         FoldingRangeRequestParams params = new FoldingRangeRequestParams(textDocumentIdentifier);


### PR DESCRIPTION
## Purpose
Two related fixes that surfaced while running the plugin against a real language server on IntelliJ IDEA 2024.3:

1. `LSPFoldingRangeProvider.buildLanguageFoldRegions` throws a `NullPointerException` when a folding pass runs on a file that has no connected/initialized language server. `LanguageServerWrapper.forVirtualFile(...)` returns `null` (and `getRequestManager()` stays `null` until the server initializes), but the code dereferences it unconditionally.
2. The integration docs instruct plugin authors to register the server definition from a `PreloadingActivity`. `PreloadingActivity` is not run on IntelliJ 2024.3, so following the docs leaves the client uninitialized and the server never connects.

No linked issue.

## Goals
- Stop the folding provider from crashing when no language server is connected yet.
- Point plugin authors at a startup mechanism that actually runs on the supported IntelliJ versions (2024.3+).

## Approach
1. Add a guard in `LSPFoldingRangeProvider`: return early when `wrapper == null || wrapper.getRequestManager() == null`.
2. Update `README.md`, `docs/developer-guide.md`, and `resources/plugin.xml.example` to use `ProjectActivity` registered via the `postStartupActivity` extension point instead of `PreloadingActivity`.

## User stories
N/A

## Release note
Fixed a `NullPointerException` in the LSP folding provider when a file is opened before its language server is connected. Updated integration docs to use `ProjectActivity`/`postStartupActivity` (IntelliJ 2024.3+) instead of the no-longer-invoked `PreloadingActivity`.

## Documentation
Updated in this PR: `README.md`, `docs/developer-guide.md`, `resources/plugin.xml.example`.

## Training
N/A

## Certification
N/A

## Marketing
N/A

## Automation tests
 - Unit tests
   > None added. The folding guard is a null-check on a path that requires a live editor plus a language-server lifecycle, which the current test harness does not cover.
 - Integration tests
   > None added. Verified manually by running the plugin via `./gradlew runIde` against the Ballerina language server (`bal start-language-server`) on IntelliJ IDEA Community 2024.3: the folding NPE no longer occurs, and the server connects and initializes through the `postStartupActivity`.

## Security checks
 - Followed secure coding standards? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
N/A

## Related PRs
N/A

## Migrations (if applicable)
N/A

## Test environment
JDK 17 (Gradle toolchain); macOS; IntelliJ IDEA Community 2024.3; Ballerina 2201.13.4.

## Learning
Confirmed via the platform bytecode that on 2024.3 `PreloadingActivity.execute()` delegates to the no-arg `preload()` and the extension is not invoked in practice; `ProjectActivity` via `postStartupActivity` is the current startup mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

- Improved folding range stability by adding null checks before requesting folding data, preventing crashes when a language server wrapper or request manager is not yet available.
- Updated IntelliJ plugin setup guidance to use `ProjectActivity` with `postStartupActivity` instead of `PreloadingActivity`, and aligned the README, developer guide, and example plugin XML with the current startup behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->