### PR TITLE
Decompose EditorEventManager into per-feature classes

### DIFF
--- a/docs/adr/0003-feature-layer-decomposition.md
+++ b/docs/adr/0003-feature-layer-decomposition.md
@@ -110,7 +110,7 @@ separately, not something this decomposition redesigns).
 
 `ARCHITECTURE.md` section 2.4's target class list also names `FoldingFeature`, `SymbolFeature`, and
 `CommandFeature`. Section 3's actual Phase 3 migration-order bullet does not include them — it
-lists exactly the seven extractions above. Checked against the current code before treating that as
+lists exactly the eight extractions above. Checked against the current code before treating that as
 settled: folding (`LSPFoldingRangeProvider`) and symbols (`LSPSymbolContributor`/
 `WorkspaceSymbolProvider`) already live in their own independent contributor classes and were never
 part of `EditorEventManager`, so there is no god-class coupling for an extraction to fix there;

--- a/docs/adr/0003-feature-layer-decomposition.md
+++ b/docs/adr/0003-feature-layer-decomposition.md
@@ -5,7 +5,7 @@
 
 ## Context
 
-Before this decision, `EditorEventManager` was 1752 lines implementing hover, completion,
+Before this decision, `EditorEventManager` was 1672 lines implementing hover, completion,
 diagnostics, code actions, signature help, navigation, rename, formatting, snippet expansion,
 text-edit application, command execution, document-sync wiring, and Swing cursor/hint
 manipulation, all in one class (`ARCHITECTURE.md` P4). Consequences:
@@ -187,6 +187,31 @@ with no lock at all (`if (annotations == null) { annotations = new ArrayList<>()
 accessors beside it are `synchronized`. That is pre-existing and was moved verbatim under point 7,
 and it means the annotation state was never fully protected by the manager's monitor either.
 
+### 7c. Three behavior changes that are not verbatim relocations
+
+Rule 5 below requires a bug fixed during an extraction to be called out rather than folded silently
+into the move. Three such changes are in this phase, each in its own commit:
+
+- **`NavigationFeature.references(...)` returns empty lists instead of `new Pair<>(null, null)` when
+  the server reports no references.** `LSPInplaceRenamer.collectRefs()` streams the first list and
+  hands the second to `LSPRenameProcessor.addEditors()`, which calls `addAll` on it; both threw a
+  `NullPointerException` on the old null result. The four callers that do check for null
+  (`LSPRenameHandler`, `LSPReferencesAction`, `LSPRenameProcessor`, `RenameFeature`) treat an empty
+  list the same way they treated null — `LSPReferencesAction` still reports "No references found".
+- **`SignatureHelpFeature` guards the active-signature and active-parameter indices.** Both are
+  nullable `Integer` in the LSP spec ("if omitted... defaults to zero") and a server may also send an
+  out-of-range value; the old code unboxed them directly and indexed with them, so either case threw.
+  Out of range or absent now falls back to `0`, and a valid `0` is still honored.
+- **`SignatureHelpFeature` also null-checks `activeSignature.getParameters()`.** This one is a
+  consequence of the guard above rather than a separately intended fix: when a server omits
+  `parameters`, the old code threw, was caught, logged a warning, and showed no hint at all; it now
+  renders the signature with an empty active parameter, which is the same path the old code took
+  whenever the parameter index was merely out of range.
+
+Everything else in this phase is a verbatim relocation per point 7. The two decisions in points 4b
+and 7b are also not verbatim, but they are consequences of moving code into `final` classes in
+another package, not fixes to the logic itself.
+
 ### 8. Tests were added only where a feature has an isolable, pure part
 
 A unit test was added per feature only where genuine pure logic existed that needed neither a
@@ -199,9 +224,22 @@ real editor navigation/selection behavior. `LspServerIntegrationTest` does not r
 request paths (it covers only open/didOpen, edit/didChange, and close/didClose/shutdown) — this is
 a pre-existing coverage gap this phase did not introduce and was not scoped to close.
 
+`CodeActionFeature` has one package-private method that exists only for its test:
+`markCodeActionSyncRequiredForTest()`. Every production path that raises `codeActionSyncRequired`
+sits inside `showCodeActions`, which needs a real editor and a server response, so without the seam
+the flag can only ever be observed in its initial `false` state — and a test asserting it is `false`
+after `getAnnotations()` would pass even if `getAnnotations()` stopped clearing it. Both tests that
+cover this bookkeeping were verified by mutation: removing the flag clear from `getAnnotations()`,
+and making `getSilentAnnotations()` return a defensive copy instead of the live list, each fail the
+corresponding test. Prefer a package-private seam over widening public API when a flag is otherwise
+unobservable, and check that a new test fails against the defect it is meant to catch.
+
+Note that `checkstyleTest` is disabled in `build.gradle`, so test sources are not style-checked;
+"checkstyle passes" for this phase means `checkstyleMain`.
+
 ## Consequences
 
-- `EditorEventManager` shrank from 1752 to 884 lines. What remains is intentionally not
+- `EditorEventManager` shrank from 1672 to 884 lines. What remains is intentionally not
   feature-layer material yet: the mouse/ctrl-range glue (point 5), `applyEdit`/`getEditsRunnable`/
   `LSPTextEdit` (the future `WorkspaceEditApplier`, referenced via `EditApplier` in the meantime),
   and document-lifecycle delegation to `DocumentEventManager` (`documentOpened`/`Closed`/`Changed`/

--- a/docs/adr/0003-feature-layer-decomposition.md
+++ b/docs/adr/0003-feature-layer-decomposition.md
@@ -1,0 +1,179 @@
+# ADR 0003: Feature-layer decomposition of EditorEventManager
+
+- Status: Accepted
+- Date: 2026-08-10
+
+## Context
+
+Before this decision, `EditorEventManager` was 1752 lines implementing hover, completion,
+diagnostics, code actions, signature help, navigation, rename, formatting, snippet expansion,
+text-edit application, command execution, document-sync wiring, and Swing cursor/hint
+manipulation, all in one class (`ARCHITECTURE.md` P4). Consequences:
+
+- Every feature change touched this one file, and the try/catch/timeout/notify pattern around
+  requests was duplicated across it (partly addressed by
+  [[0001-threading-and-concurrency-model]]'s `RequestExecutor`, but the duplication of the
+  surrounding feature logic itself remained).
+- Zero tests existed for any of this logic (`ARCHITECTURE.md` P8): the fields a test would need to
+  set up or assert on (diagnostics, annotations, completion triggers, the ctrl-range highlight)
+  were private and entangled with each other and with `Editor`/`Project` state, with no seam to
+  construct or verify one feature in isolation.
+- Extending behavior meant subclassing `EditorEventManager` itself — inheriting every other
+  feature along with the one being customized.
+
+## Decision
+
+### 1. One class per LSP feature, under `org.wso2.lsp4intellij.features`
+
+Eight classes were extracted, each composed once per editor by `EditorEventManager`'s constructor,
+in the exact order `ARCHITECTURE.md` section 3's Phase 3 bullet specifies (diagnostics →
+completion → hover/signature → navigation → code actions → rename → formatting), one per commit on
+`phase-3-features`:
+
+`DiagnosticsFeature`, `CompletionFeature`, `HoverFeature`, `SignatureHelpFeature`,
+`NavigationFeature`, `CodeActionFeature`, `RenameFeature`, `FormattingFeature`.
+
+Each takes exactly the editor/project/wrapper/identifier state it needs and nothing else — no
+static lookups, no reference back to the `EditorEventManager` that composes it.
+
+### 2. `EditorEventManager` keeps every public method as an unchanged-signature facade
+
+Every method `EditorEventManager` exposed before this phase — `getDiagnostics`, `completion`,
+`createLookupItem`, `getCompletionPrefix`, `quickDoc`, `characterTyped`, `references`,
+`gotoLocation`, `codeAction`, `executeCommands`, `requestAndShowCodeActions`, `getSilentAnnotations`,
+`triggerIntentionActions`, `rename`, `reformat`, `reformatSelection`, and more — now delegates to
+the feature that owns it, with the exact same signature it had before.
+
+This was not optional: unlike Phase 2's `IntellijLanguageClient`/`LanguageServerWrapper` static
+facades, callers here reach `EditorEventManager` directly, by concrete type, from all across the
+codebase — `LSPAnnotator`, `LSPCompletionContributor`, `LSPTypedHandler`, `LSPQuickDocAction`,
+`LSPReferencesAction`, `LSPRenameHandler`/`LSPRenameProcessor`/`LSPInplaceRenamer`,
+`LSPCommandFix`/`LSPCodeActionFix`, `ReformatHandler`, `LSPShowReformatDialogAction`, and
+`LSPCaretListenerImpl` all call one or more of these methods on an `EditorEventManager` instance,
+some also reading the public `completionTriggers` field directly. There is no interface boundary
+between them and this class to insulate a signature change.
+
+### 3. Missing shared state: narrow injected callbacks, not a premature `EditorContext`
+
+`ARCHITECTURE.md` section 2.4 describes `EditorContext`, a shared per-editor object features would
+depend on for exactly this kind of cross-feature state. It doesn't exist yet — building it was not
+in this phase's scope, and speculatively designing it around only eight call sites risked getting
+its shape wrong. Where an extracted feature needed a capability that isn't extracted yet, it takes
+that capability as a small constructor-injected callback instead:
+
+- **`EditApplier`** (`org.wso2.lsp4intellij.features.EditApplier`, a `@FunctionalInterface`
+  matching `EditorEventManager.applyEdit(int, List, String, boolean, boolean)`) — injected into
+  `CompletionFeature` and `FormattingFeature`, since text-edit application (the future
+  `WorkspaceEditApplier`) is not extracted yet. Started as a nested type inside `CompletionFeature`;
+  promoted to a shared top-level interface once `FormattingFeature` needed the identical shape,
+  rather than duplicating it.
+- **`Consumer<List<Command>>`** matching `executeCommands` — injected into `CompletionFeature`,
+  since command execution ended up owned by `CodeActionFeature` (shared with code-action and
+  command quick-fixes), not by completion itself.
+- **`Runnable`** matching `signatureHelp()` — injected into `CompletionFeature`, called after
+  expanding a snippet.
+- **`Consumer<Hint>`** — the currently-shown editor hint (`currentHint`) stayed a field on
+  `EditorEventManager`, because `mouseMoved`'s hover-dwell logic reads it to hide a stale hint
+  before showing a new one. `HoverFeature` and `SignatureHelpFeature` each take a setter callback
+  instead of owning the field.
+
+These callbacks are deliberately narrower than a full `EditorContext` reference. When that object
+is built in a later phase, each of these constructor parameters should be replaced by a reference
+to it rather than kept alongside it.
+
+### 4. Already-extracted features compose each other directly, not through callbacks
+
+Where one feature's logic genuinely depends on another's, and both are already extracted, the
+dependent feature takes the other feature object directly as a constructor parameter — ordinary
+composition, not a stand-in for anything:
+
+- `CodeActionFeature` takes a `DiagnosticsFeature` (to read the diagnostic context for a code-action
+  request, and to force re-annotation after attaching a fix).
+- `RenameFeature` takes a `NavigationFeature` (to find references, so files opened only to compute
+  the rename can be closed again afterward).
+
+### 5. Mouse/ctrl-range navigation glue stays in `EditorEventManager`
+
+`mouseMoved`, `mouseClicked`, `createCtrlRange`, `trySourceNavigationAndHover`, and `getPos` were
+not extracted. They decide *whether and when* a mouse event should trigger hover, a navigation
+preview highlight, or nothing — reading and writing the ctrl-range global slot on
+`EditorEventManagerBase` to do it — which is mouse/UI event-routing glue that spans features, not
+one LSP feature's logic itself. They now call `hoverFeature.showHoverAt(...)`,
+`navigationFeature.definition(...)`, and `navigationFeature.gotoLocation(...)` for the actual work.
+
+`EditorEventManagerBase.getIsCtrlDown()` widened from package-private to public: `HoverFeature`,
+now in a different package, needs to read it to decide how to show a hint. It stays a pre-existing
+global static flag otherwise (part of the P6 static-state debt `ARCHITECTURE.md` tracks
+separately, not something this decomposition redesigns).
+
+### 6. Folding, symbols, and commands were considered and excluded
+
+`ARCHITECTURE.md` section 2.4's target class list also names `FoldingFeature`, `SymbolFeature`, and
+`CommandFeature`. Section 3's actual Phase 3 migration-order bullet does not include them — it
+lists exactly the seven extractions above. Checked against the current code before treating that as
+settled: folding (`LSPFoldingRangeProvider`) and symbols (`LSPSymbolContributor`/
+`WorkspaceSymbolProvider`) already live in their own independent contributor classes and were never
+part of `EditorEventManager`, so there is no god-class coupling for an extraction to fix there;
+commands (`executeCommands`) already moved into `CodeActionFeature` per point 3 above. Moving any
+of the three into `org.wso2.lsp4intellij.features` now would rename already-independent code for
+consistency alone, which this phase treats as out of scope.
+
+### 7. Extractions preserve behavior, including pre-existing quirks
+
+Each method's body was moved verbatim, not opportunistically cleaned up, consistent with
+[[0002-project-and-application-scoped-server-registries]]'s precedent of relocating state without
+redesigning it in the same change. Two examples kept as-is: `createLookupItem`'s unused local
+`command`/`addTextEdits` variables (recomputed from `item` again inside
+`addCompletionInsertHandlers`), and `DiagnosticsFeature`'s locking split (synchronized accessor
+methods for reads vs. `synchronized (this.diagnostics)` blocks for the mutation and the
+code-action-context read) — a real pre-existing inconsistency, left as found rather than fixed as
+an unannounced side effect of the move.
+
+### 8. Tests were added only where a feature has an isolable, pure part
+
+A unit test was added per feature only where genuine pure logic existed that needed neither a
+running language server nor a real `Editor`'s UI behavior: `DiagnosticsFeatureTest`,
+`CompletionFeatureTest` (scoped to `getCompletionPrefix`), `SignatureHelpFeatureTest` (scoped to
+the trigger-character gate), `CodeActionFeatureTest` (scoped to the annotation/sync-flag
+bookkeeping). `HoverFeature`, `NavigationFeature`, `RenameFeature`, and `FormattingFeature` have no
+such test: every one of their methods needs the wrapper's request manager (a running server) or
+real editor navigation/selection behavior. `LspServerIntegrationTest` does not reach any of these
+request paths (it covers only open/didOpen, edit/didChange, and close/didClose/shutdown) — this is
+a pre-existing coverage gap this phase did not introduce and was not scoped to close.
+
+## Consequences
+
+- `EditorEventManager` shrank from 1752 to 884 lines. What remains is intentionally not
+  feature-layer material yet: the mouse/ctrl-range glue (point 5), `applyEdit`/`getEditsRunnable`/
+  `LSPTextEdit` (the future `WorkspaceEditApplier`, referenced via `EditApplier` in the meantime),
+  and document-lifecycle delegation to `DocumentEventManager` (`documentOpened`/`Closed`/`Changed`/
+  `Saved`, `willSave`/`willSaveWaitUntil` — the future `DocumentSynchronizer` from section 2.3,
+  never in this phase's scope).
+- No public API changed. Every downstream plugin calling `EditorEventManager`,
+  `IntellijLanguageClient`, or `LanguageServerWrapper` compiles and behaves identically.
+- The `EditApplier`/command/signature-help/hint callbacks introduced in point 3 are scaffolding,
+  not a final design — expected to be replaced by a real `EditorContext` reference once a later
+  phase builds one, per Rule 3 below.
+- `LSPFoldingRangeProvider` and `LSPSymbolContributor`/`WorkspaceSymbolProvider` are unchanged by
+  this ADR; nothing about them was judged broken.
+
+## Rules for new code
+
+1. New LSP feature logic is added to its own class under `org.wso2.lsp4intellij.features`, not to
+   `EditorEventManager`.
+2. Before removing or changing the signature of any `EditorEventManager` public method, check for
+   direct external callers first — contributors, actions, and quick-fixes call it by concrete type
+   across the codebase, not through an interface, so a signature change is a compile break for them,
+   not a caught-by-the-compiler-in-one-place change.
+3. When a new feature needs a capability that isn't extracted yet, inject it as a narrow callback
+   (the `EditApplier` pattern), rather than reaching back into `EditorEventManager`'s private state
+   or duplicating the logic. When `EditorContext` is eventually built, replace these callbacks with
+   a reference to it rather than keeping both.
+4. When one already-extracted feature depends on another, compose the dependency directly as a
+   constructor parameter (peer composition), not through `EditorEventManager`.
+5. Preserve exact behavior, including pre-existing quirks, when relocating code out of
+   `EditorEventManager`. Fixing a bug noticed during an extraction is a separate, explicitly called
+   out decision, not a silent side effect of moving the code.
+6. Add a unit test for a new feature's pure/isolable logic; when a feature has none because every
+   path needs a running server or real editor UI behavior, say so in its javadoc rather than
+   skipping the test silently.

--- a/docs/adr/0003-feature-layer-decomposition.md
+++ b/docs/adr/0003-feature-layer-decomposition.md
@@ -89,8 +89,35 @@ composition, not a stand-in for anything:
 
 - `CodeActionFeature` takes a `DiagnosticsFeature` (to read the diagnostic context for a code-action
   request, and to force re-annotation after attaching a fix).
-- `RenameFeature` takes a `NavigationFeature` (to find references, so files opened only to compute
-  the rename can be closed again afterward).
+
+`RenameFeature` is the exception: it needs reference lookup, but reaches it through the
+`ReferenceLookup` interface rather than a direct `NavigationFeature`, for the dispatch reason in
+point 4b.
+
+### 4b. Self-calls that used to be virtual are re-dispatched through the facade
+
+Inside the old single class, some public methods were called unqualified from other methods of the
+same class, so they dispatched virtually. `LSPExtensionManager.getExtendedEditorEventManagerFor`
+lets an extension supply an `EditorEventManager` subclass, and `LanguageServerWrapper` installs it
+for every editor, so an override of one of those methods took effect on the internal path that
+called it. The feature classes are `final`, so an ordinary self-call inside one can never reach such
+an override — the call would silently run the base implementation while the facade method stayed
+overridable, so a signature-level API check would not catch the change.
+
+Six calls were affected. They now go back through the composing `EditorEventManager`, via three
+interfaces it implements using the method signatures it already exposed:
+
+- `CompletionOverrides` — `createLookupItem` (called from `completion`),
+  `addCompletionInsertHandlers` (from `createLookupItem`), `prepareAndRunSnippet` (from the three
+  insert handlers).
+- `CodeActionOverrides` — `codeAction` and `resolvedCodeAction` (both from
+  `requestAndShowCodeActions`). Neither has any other caller in this codebase; being overridden was
+  their only purpose.
+- `ReferenceLookup` — `references(int, boolean, boolean)` (from `rename`).
+
+These are interfaces, not an `EditorEventManager` reference, so point 1's rule that a feature holds
+no reference back to the class composing it still holds. No recursion results: the facade method
+forwards to the feature method that does the work, and that method does not re-enter the same hook.
 
 ### 5. Mouse/ctrl-range navigation glue stays in `EditorEventManager`
 

--- a/docs/adr/0003-feature-layer-decomposition.md
+++ b/docs/adr/0003-feature-layer-decomposition.md
@@ -156,6 +156,37 @@ methods for reads vs. `synchronized (this.diagnostics)` blocks for the mutation 
 code-action-context read) — a real pre-existing inconsistency, left as found rather than fixed as
 an unannounced side effect of the move.
 
+### 7b. One deviation from that: the six accessors' monitor was split in two
+
+`getDiagnostics`, `getAnnotations`, `setAnnotations`, `setAnonHolder`, `isDiagnosticSyncRequired`,
+and `isCodeActionSyncRequired` were all `public synchronized` on `EditorEventManager`, so all six
+locked the same object: the manager instance. They are now unsynchronized delegating methods, and
+the `synchronized` sits on the two feature classes that hold the state — `DiagnosticsFeature`
+(`diagnostics`, `syncRequired`) and `CodeActionFeature` (`annotations`, `anonHolder`,
+`codeActionSyncRequired`). One monitor became two, so a call in the first group and a call in the
+second group can now run at the same time.
+
+That does not break an invariant. The two state groups are disjoint — no field is read or written by
+both — so every pair of calls that stopped excluding each other operates on different fields. The
+exclusion between the groups came from both groups happening to use `this` as their monitor, not
+from anything either group needed from the other. The modifier also only ever made a single call
+atomic, never a sequence of them: `LSPAnnotator` reads the diagnostics, builds annotations from
+them, then calls `setAnnotations` and `setAnonHolder`, and the lock was released between each of
+those calls before this change too.
+
+What the split does remove is the ability of code outside this class to write
+`synchronized (manager) { ... }` and block these accessors, and a subclass's `super.getAnnotations()`
+no longer acquires the manager's monitor. Nothing in this repository does either; a downstream
+plugin could. The modifier was not restored on the delegating methods, because it guards no
+invariant and would add a second lock acquisition to a path `LSPAnnotator` runs on every
+`DaemonCodeAnalyzer` pass. Callers should treat each accessor as individually safe to call from any
+thread and not assume a sequence of them is atomic — which was already true before this change.
+
+For the same reason, note that `CodeActionFeature.showCodeActions` reads and assigns `annotations`
+with no lock at all (`if (annotations == null) { annotations = new ArrayList<>(); }`) while the
+accessors beside it are `synchronized`. That is pre-existing and was moved verbatim under point 7,
+and it means the annotation state was never fully protected by the manager's monitor either.
+
 ### 8. Tests were added only where a feature has an isolable, pure part
 
 A unit test was added per feature only where genuine pure logic existed that needed neither a
@@ -176,8 +207,11 @@ a pre-existing coverage gap this phase did not introduce and was not scoped to c
   and document-lifecycle delegation to `DocumentEventManager` (`documentOpened`/`Closed`/`Changed`/
   `Saved`, `willSave`/`willSaveWaitUntil` — the future `DocumentSynchronizer` from section 2.3,
   never in this phase's scope).
-- No public API changed. Every downstream plugin calling `EditorEventManager`,
-  `IntellijLanguageClient`, or `LanguageServerWrapper` compiles and behaves identically.
+- No public method signature changed, so every downstream plugin calling `EditorEventManager`,
+  `IntellijLanguageClient`, or `LanguageServerWrapper` still compiles. Two behavioral details do
+  differ: the six accessors in point 7b no longer lock the manager instance, and a subclass override
+  of a method listed in point 4b now takes effect only because the call was routed back through the
+  facade — an ordinary self-call inside a `final` feature class would have skipped it.
 - The `EditApplier`/command/signature-help/hint callbacks introduced in point 3 are scaffolding,
   not a final design — expected to be replaced by a real `EditorContext` reference once a later
   phase builds one, per Rule 3 below.

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -28,7 +28,6 @@ import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.LogicalPosition;
-import com.intellij.openapi.editor.SelectionModel;
 import com.intellij.openapi.editor.colors.EditorColors;
 import com.intellij.openapi.editor.event.DocumentEvent;
 import com.intellij.openapi.editor.event.DocumentListener;
@@ -56,9 +55,6 @@ import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
-import org.eclipse.lsp4j.DocumentFormattingParams;
-import org.eclipse.lsp4j.DocumentRangeFormattingParams;
-import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.InsertReplaceEdit;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
@@ -78,6 +74,7 @@ import org.wso2.lsp4intellij.contributors.fixes.LSPCodeActionFix;
 import org.wso2.lsp4intellij.features.CodeActionFeature;
 import org.wso2.lsp4intellij.features.CompletionFeature;
 import org.wso2.lsp4intellij.features.DiagnosticsFeature;
+import org.wso2.lsp4intellij.features.FormattingFeature;
 import org.wso2.lsp4intellij.features.HoverFeature;
 import org.wso2.lsp4intellij.features.NavigationFeature;
 import org.wso2.lsp4intellij.features.RenameFeature;
@@ -98,7 +95,6 @@ import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getIsCtrlDown;
 import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getIsKeyPressed;
 import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.setCtrlRange;
 import static org.wso2.lsp4intellij.requests.Timeouts.WILLSAVE;
-import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableReadAction;
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeLater;
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.writeAction;
 import static org.wso2.lsp4intellij.utils.DocumentUtils.toEither;
@@ -146,6 +142,7 @@ public class EditorEventManager {
     private final NavigationFeature navigationFeature;
     private final CodeActionFeature codeActionFeature;
     private final RenameFeature renameFeature;
+    private final FormattingFeature formattingFeature;
 
     private static final long CTRL_THRESH = EditorSettingsExternalizable.getInstance().getTooltipsDelay() * 1000000;
 
@@ -182,6 +179,7 @@ public class EditorEventManager {
         this.navigationFeature = new NavigationFeature(editor, project, wrapper, identifier);
         this.codeActionFeature = new CodeActionFeature(editor, wrapper, identifier, diagnosticsFeature);
         this.renameFeature = new RenameFeature(editor, project, wrapper, identifier, navigationFeature);
+        this.formattingFeature = new FormattingFeature(editor, wrapper, identifier, this::applyEdit);
 
         EditorEventManagerBase.registerManager(this);
 
@@ -419,66 +417,14 @@ public class EditorEventManager {
      * Reformat the whole document.
      */
     public void reformat() {
-        wrapper.pool(() -> {
-            if (editor.isDisposed()) {
-                return;
-            }
-            DocumentFormattingParams params = new DocumentFormattingParams();
-            params.setTextDocument(identifier);
-            FormattingOptions options = new FormattingOptions();
-            options.setTabSize(DocumentUtils.getTabSize(editor));
-            options.setInsertSpaces(DocumentUtils.shouldUseSpaces(editor));
-            params.setOptions(options);
-
-            CompletableFuture<List<? extends TextEdit>> request = wrapper.getRequestManager().formatting(params);
-            if (request == null) {
-                return;
-            }
-            request.thenAccept(formatting -> {
-                if (formatting != null) {
-                    invokeLater(() -> applyEdit(toEither((List<TextEdit>) formatting), "Reformat document", false));
-                }
-            });
-        });
+        formattingFeature.reformat();
     }
 
     /**
      * Reformat the text currently selected in the editor.
      */
     public void reformatSelection() {
-        wrapper.pool(() -> {
-            if (editor.isDisposed()) {
-                return;
-            }
-            DocumentRangeFormattingParams params = new DocumentRangeFormattingParams();
-            params.setTextDocument(identifier);
-            SelectionModel selectionModel = editor.getSelectionModel();
-            int start = computableReadAction(selectionModel::getSelectionStart);
-            int end = computableReadAction(selectionModel::getSelectionEnd);
-            Position startingPos = DocumentUtils.offsetToLSPPos(editor, start);
-            Position endPos = DocumentUtils.offsetToLSPPos(editor, end);
-            params.setRange(new Range(startingPos, endPos));
-            // Todo - Make Formatting Options configurable
-            FormattingOptions options = new FormattingOptions();
-            options.setTabSize(DocumentUtils.getTabSize(editor));
-            options.setInsertSpaces(DocumentUtils.shouldUseSpaces(editor));
-            params.setOptions(options);
-
-            CompletableFuture<List<? extends TextEdit>> request = wrapper.getRequestManager().rangeFormatting(params);
-            if (request == null) {
-                return;
-            }
-            request.thenAccept(formatting -> {
-                if (formatting == null) {
-                    return;
-                }
-                invokeLater(() -> {
-                    if (!editor.isDisposed()) {
-                        applyEdit(toEither((List<TextEdit>) formatting), "Reformat selection", false);
-                    }
-                });
-            });
-        });
+        formattingFeature.reformatSelection();
     }
 
     public void rename(String renameTo) {

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -63,13 +63,11 @@ import org.eclipse.lsp4j.InsertReplaceEdit;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.RenameParams;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentSaveReason;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WillSaveTextDocumentParams;
-import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.jetbrains.annotations.NotNull;
 import org.wso2.lsp4intellij.actions.LSPReferencesAction;
@@ -77,22 +75,20 @@ import org.wso2.lsp4intellij.client.languageserver.ServerOptions;
 import org.wso2.lsp4intellij.client.languageserver.requestmanager.RequestManager;
 import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
 import org.wso2.lsp4intellij.contributors.fixes.LSPCodeActionFix;
-import org.wso2.lsp4intellij.contributors.rename.LSPRenameProcessor;
 import org.wso2.lsp4intellij.features.CodeActionFeature;
 import org.wso2.lsp4intellij.features.CompletionFeature;
 import org.wso2.lsp4intellij.features.DiagnosticsFeature;
 import org.wso2.lsp4intellij.features.HoverFeature;
 import org.wso2.lsp4intellij.features.NavigationFeature;
+import org.wso2.lsp4intellij.features.RenameFeature;
 import org.wso2.lsp4intellij.features.SignatureHelpFeature;
 import org.wso2.lsp4intellij.listeners.LSPCaretListenerImpl;
-import org.wso2.lsp4intellij.requests.WorkspaceEditHandler;
 import org.wso2.lsp4intellij.utils.DocumentUtils;
 import org.wso2.lsp4intellij.utils.FileUtils;
 
 import java.awt.Cursor;
 import java.awt.Point;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -149,6 +145,7 @@ public class EditorEventManager {
     private final SignatureHelpFeature signatureHelpFeature;
     private final NavigationFeature navigationFeature;
     private final CodeActionFeature codeActionFeature;
+    private final RenameFeature renameFeature;
 
     private static final long CTRL_THRESH = EditorSettingsExternalizable.getInstance().getTooltipsDelay() * 1000000;
 
@@ -184,6 +181,7 @@ public class EditorEventManager {
                 hint -> this.currentHint = hint);
         this.navigationFeature = new NavigationFeature(editor, project, wrapper, identifier);
         this.codeActionFeature = new CodeActionFeature(editor, wrapper, identifier, diagnosticsFeature);
+        this.renameFeature = new RenameFeature(editor, project, wrapper, identifier, navigationFeature);
 
         EditorEventManagerBase.registerManager(this);
 
@@ -484,7 +482,7 @@ public class EditorEventManager {
     }
 
     public void rename(String renameTo) {
-        rename(renameTo, editor.getCaretModel().getCurrentCaret().getOffset());
+        renameFeature.rename(renameTo);
     }
 
     /**
@@ -493,36 +491,7 @@ public class EditorEventManager {
      * @param renameTo The new name
      */
     public void rename(String renameTo, int offset) {
-        wrapper.pool(() -> {
-            if (editor.isDisposed()) {
-                return;
-            }
-            VirtualFile[] openedFiles = FileEditorManager.getInstance(project).getOpenFiles();
-            Pair<List<PsiElement>, List<VirtualFile>> references = references(offset, true, false);
-            List<VirtualFile> toClose = new ArrayList<>();
-            if (references.getSecond() != null) {
-                for (VirtualFile file : references.getSecond()) {
-                    if (!Arrays.asList(openedFiles).contains(file)) {
-                        toClose.add(file);
-                    }
-                }
-            }
-            Position servPos = DocumentUtils.offsetToLSPPos(editor, offset);
-            RenameParams params = new RenameParams(identifier, servPos, renameTo);
-            CompletableFuture<WorkspaceEdit> request = wrapper.getRequestManager().rename(params);
-            if (request != null) {
-                request.thenAccept(res -> {
-                    boolean isApplied = WorkspaceEditHandler.applyEdit(res, "Rename to " + renameTo, toClose);
-                    LSPRenameProcessor.clearEditors();
-                    if (!isApplied) {
-                        for (VirtualFile file : toClose) {
-                            invokeLater(() -> writeAction(
-                                    () -> FileEditorManager.getInstance(project).closeFile(file)));
-                        }
-                    }
-                });
-            }
-        });
+        renameFeature.rename(renameTo, offset);
     }
 
     /**

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -15,14 +15,9 @@
  */
 package org.wso2.lsp4intellij.editor;
 
-import com.intellij.codeInsight.completion.InsertionContext;
 import com.intellij.codeInsight.hint.HintManager;
-import com.intellij.codeInsight.lookup.AutoCompletionPolicy;
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
-import com.intellij.codeInsight.template.TemplateManager;
-import com.intellij.codeInsight.template.impl.TemplateImpl;
-import com.intellij.codeInsight.template.impl.TextExpression;
 import com.intellij.lang.Language;
 import com.intellij.lang.LanguageDocumentation;
 import com.intellij.lang.annotation.Annotation;
@@ -34,7 +29,6 @@ import com.intellij.openapi.command.CommandProcessor;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
-import com.intellij.openapi.editor.EditorModificationUtil;
 import com.intellij.openapi.editor.LogicalPosition;
 import com.intellij.openapi.editor.ScrollType;
 import com.intellij.openapi.editor.SelectionModel;
@@ -71,9 +65,6 @@ import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.CompletionItem;
-import org.eclipse.lsp4j.CompletionItemKind;
-import org.eclipse.lsp4j.CompletionList;
-import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.DefinitionParams;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
@@ -84,7 +75,6 @@ import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.Hover;
 import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.InsertReplaceEdit;
-import org.eclipse.lsp4j.InsertTextFormat;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.MarkupContent;
@@ -112,16 +102,15 @@ import org.wso2.lsp4intellij.client.languageserver.requestmanager.RequestManager
 import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
 import org.wso2.lsp4intellij.contributors.fixes.LSPCodeActionFix;
 import org.wso2.lsp4intellij.contributors.fixes.LSPCommandFix;
-import org.wso2.lsp4intellij.contributors.icon.LSPIconProvider;
 import org.wso2.lsp4intellij.contributors.psi.LSPPsiElement;
 import org.wso2.lsp4intellij.contributors.rename.LSPRenameProcessor;
+import org.wso2.lsp4intellij.features.CompletionFeature;
 import org.wso2.lsp4intellij.features.DiagnosticsFeature;
 import org.wso2.lsp4intellij.listeners.LSPCaretListenerImpl;
 import org.wso2.lsp4intellij.requests.HoverHandler;
 import org.wso2.lsp4intellij.requests.WorkspaceEditHandler;
 import org.wso2.lsp4intellij.utils.DocumentUtils;
 import org.wso2.lsp4intellij.utils.FileUtils;
-import org.wso2.lsp4intellij.utils.GUIUtils;
 
 import java.awt.Cursor;
 import java.awt.Font;
@@ -131,21 +120,15 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
-
-import javax.swing.Icon;
 
 import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getCtrlRange;
 import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getIsCtrlDown;
 import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getIsKeyPressed;
 import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.setCtrlRange;
 import static org.wso2.lsp4intellij.requests.Timeouts.CODEACTION;
-import static org.wso2.lsp4intellij.requests.Timeouts.COMPLETION;
 import static org.wso2.lsp4intellij.requests.Timeouts.DEFINITION;
 import static org.wso2.lsp4intellij.requests.Timeouts.EXECUTE_COMMAND;
 import static org.wso2.lsp4intellij.requests.Timeouts.HOVER;
@@ -197,13 +180,12 @@ public class EditorEventManager {
     private Hint currentHint;
 
     private final DiagnosticsFeature diagnosticsFeature;
+    private final CompletionFeature completionFeature;
     private AnnotationHolder anonHolder;
     private List<Annotation> annotations = new ArrayList<>();
     private volatile boolean codeActionSyncRequired = false;
 
     private static final long CTRL_THRESH = EditorSettingsExternalizable.getInstance().getTooltipsDelay() * 1000000;
-
-    public static final String SNIPPET_PLACEHOLDER_REGEX = "(\\$\\{\\d+:?(\\{)?[^{}]*(\\})?\\}|\\$\\d+)";
 
     private final List<Tuple3<HighlightSeverity, TextRange, LSPCodeActionFix>> silentAnnotations = new ArrayList<>();
 
@@ -234,6 +216,8 @@ public class EditorEventManager {
 
         this.project = editor.getProject();
         this.diagnosticsFeature = new DiagnosticsFeature(editor, project);
+        this.completionFeature = new CompletionFeature(editor, project, wrapper, identifier, completionTriggers,
+                this::applyEdit, this::executeCommands, this::signatureHelp);
 
         EditorEventManagerBase.registerManager(this);
 
@@ -834,31 +818,7 @@ public class EditorEventManager {
      * @return The suggestions
      */
     public Iterable<? extends LookupElement> completion(Position pos) {
-
-        List<LookupElement> lookupItems = new ArrayList<>();
-        CompletableFuture<Either<List<CompletionItem>, CompletionList>> request = wrapper.getRequestManager()
-                .completion(new CompletionParams(identifier, pos));
-        Either<List<CompletionItem>, CompletionList> res =
-                wrapper.getRequestExecutor().waitFor(request, COMPLETION);
-        if (res == null) {
-            return lookupItems;
-        }
-        if (res.getLeft() != null) {
-            for (CompletionItem item : res.getLeft()) {
-                LookupElement lookupElement = createLookupItem(item);
-                if (lookupElement != null) {
-                    lookupItems.add(lookupElement);
-                }
-            }
-        } else if (res.getRight() != null) {
-            for (CompletionItem item : res.getRight().getItems()) {
-                LookupElement lookupElement = createLookupItem(item);
-                if (lookupElement != null) {
-                    lookupItems.add(lookupElement);
-                }
-            }
-        }
-        return lookupItems;
+        return completionFeature.completion(pos);
     }
 
     /**
@@ -869,210 +829,24 @@ public class EditorEventManager {
      */
     @SuppressWarnings("WeakerAccess")
     public LookupElement createLookupItem(CompletionItem item) {
-        Command command = item.getCommand();
-        String detail = item.getDetail();
-        String insertText = item.getInsertText();
-        CompletionItemKind kind = item.getKind();
-        String label = item.getLabel();
-        Either<TextEdit, InsertReplaceEdit> textEditEither = item.getTextEdit();
-        TextEdit textEdit = (textEditEither != null) ? textEditEither.getLeft() : null;
-        InsertReplaceEdit insertReplaceEdit = (textEditEither != null) ? textEditEither.getRight() : null;
-        List<TextEdit> addTextEdits = item.getAdditionalTextEdits();
-        String presentableText = StringUtils.isNotEmpty(label) ? label : (insertText != null) ? insertText : "";
-        String tailText = (detail != null) ? detail : "";
-        LSPIconProvider iconProvider = GUIUtils.getIconProviderFor(wrapper.getServerDefinition());
-        Icon icon = iconProvider.getCompletionIcon(kind);
-        LookupElementBuilder lookupElementBuilder;
-
-        String lookupString = null;
-        if (textEdit != null) {
-            lookupString = textEdit.getNewText();
-        } else if (insertReplaceEdit != null) {
-            lookupString = insertReplaceEdit.getNewText();
-        } else if (StringUtils.isNotEmpty(insertText)) {
-            lookupString = insertText;
-        } else if (StringUtils.isNotEmpty(label)) {
-            lookupString = label;
-        }
-        if (StringUtils.isEmpty(lookupString)) {
-            return null;
-        }
-        // Fixes IDEA internal assertion failure in windows.
-        lookupString = lookupString.replace(DocumentUtils.WIN_SEPARATOR, DocumentUtils.LINUX_SEPARATOR);
-
-        lookupElementBuilder = LookupElementBuilder.create(getLookupStringWithoutPlaceholders(item, lookupString));
-
-        lookupElementBuilder = addCompletionInsertHandlers(item, lookupElementBuilder, lookupString);
-
-        if (kind == CompletionItemKind.Keyword) {
-            lookupElementBuilder = lookupElementBuilder.withBoldness(true);
-        }
-
-        return lookupElementBuilder.withPresentableText(presentableText).withTypeText(tailText, true).withIcon(icon)
-                .withAutoCompletionPolicy(AutoCompletionPolicy.SETTINGS_DEPENDENT);
-    }
-
-    private String getLookupStringWithoutPlaceholders(CompletionItem item, String lookupString) {
-        if (item.getInsertTextFormat() == InsertTextFormat.Snippet) {
-            return convertPlaceHolders(lookupString);
-        } else {
-            return lookupString;
-        }
+        return completionFeature.createLookupItem(item);
     }
 
     @SuppressWarnings("WeakerAccess")
     public LookupElementBuilder addCompletionInsertHandlers(
             CompletionItem item, LookupElementBuilder builder,
             String lookupString) {
-
-        String label = item.getLabel();
-        Command command = item.getCommand();
-        List<TextEdit> addTextEdits = item.getAdditionalTextEdits();
-        InsertTextFormat format = item.getInsertTextFormat();
-
-        if (addTextEdits != null) {
-            builder = builder.withInsertHandler(
-                    (InsertionContext context, LookupElement lookupElement) -> invokeLater(() -> {
-                applyInitialTextEdit(item, context, lookupString);
-
-                if (format == InsertTextFormat.Snippet) {
-                    context.commitDocument();
-                    prepareAndRunSnippet(lookupString);
-                }
-
-                context.commitDocument();
-                applyEdit(Integer.MAX_VALUE, toEither(addTextEdits), "Completion : " + label, false, false);
-                if (command != null) {
-                    executeCommands(Collections.singletonList(command));
-                }
-            }));
-        } else if (command != null) {
-            builder = builder.withInsertHandler((InsertionContext context, LookupElement lookupElement) -> {
-                applyInitialTextEdit(item, context, lookupString);
-
-                if (format == InsertTextFormat.Snippet) {
-                    context.commitDocument();
-                    prepareAndRunSnippet(lookupString);
-                }
-                context.commitDocument();
-                executeCommands(Collections.singletonList(command));
-            });
-        } else {
-            builder = builder.withInsertHandler((InsertionContext context, LookupElement lookupElement) -> {
-                applyInitialTextEdit(item, context, lookupString);
-
-                if (format == InsertTextFormat.Snippet) {
-                    context.commitDocument();
-                    prepareAndRunSnippet(lookupString);
-                }
-            });
-        }
-        return builder;
-    }
-
-    private void applyInitialTextEdit(CompletionItem item, InsertionContext context, String lookupString) {
-        if (item.getTextEdit() != null) {
-            // remove intellij edit, server is controlling insertion
-            writeAction(() -> {
-                Runnable runnable = () -> this.editor.getDocument()
-                        .deleteString(context.getStartOffset(), context.getTailOffset());
-
-                CommandProcessor.getInstance()
-                        .executeCommand(project, runnable,
-                                "Removing Intellij Completion", "LSPPlugin",
-                                editor.getDocument());
-            });
-            context.commitDocument();
-
-            if (item.getTextEdit().isLeft()) {
-                item.getTextEdit().getLeft().setNewText(getLookupStringWithoutPlaceholders(item, lookupString));
-            }
-
-            applyEdit(Integer.MAX_VALUE, Collections.singletonList(item.getTextEdit()), "text edit", false, true);
-        } else {
-            // client handles insertion, determine a prefix (to allow completions of partially matching items)
-            int prefixLength = getCompletionPrefixLength(context.getStartOffset());
-
-            writeAction(() -> {
-                Runnable runnable = () -> this.editor.getDocument()
-                        .deleteString(context.getStartOffset() - prefixLength,
-                                context.getStartOffset());
-
-                CommandProcessor.getInstance()
-                        .executeCommand(project, runnable, "Removing Prefix", "LSPPlugin", editor.getDocument());
-            });
-            context.commitDocument();
-
-        }
-    }
-
-    private int getCompletionPrefixLength(int offset) {
-        return getCompletionPrefix(this.editor, offset).length();
+        return completionFeature.addCompletionInsertHandlers(item, builder, lookupString);
     }
 
     @NotNull
     public String getCompletionPrefix(Editor editor, int offset) {
-        String delimiterString = String.join("", this.completionTriggers) + " \t\n\r";
-        String documentText = editor.getDocument().getText();
-        int lastIndex = -1;
-        for (char delimiter : delimiterString.toCharArray()) {
-            int index = documentText.substring(0, offset).lastIndexOf(delimiter);
-            if (index > lastIndex) {
-                lastIndex = index;
-            }
-        }
-        return lastIndex >= 0 ? documentText.substring(lastIndex + 1, offset) : documentText.substring(0, offset);
+        return completionFeature.getCompletionPrefix(editor, offset);
     }
 
     @SuppressWarnings("WeakerAccess")
     public void prepareAndRunSnippet(String insertText) {
-
-        List<SnippetVariable> variables = new ArrayList<>();
-        // Extracts variables using placeholder REGEX pattern.
-        Matcher varMatcher = Pattern.compile(SNIPPET_PLACEHOLDER_REGEX).matcher(insertText);
-        while (varMatcher.find()) {
-            variables.add(new SnippetVariable(varMatcher.group(), varMatcher.start(), varMatcher.end()));
-        }
-        if (variables.isEmpty()) {
-            return;
-        }
-        variables.sort(Comparator.comparingInt(o -> o.startIndex));
-        final String[] finalInsertText = {insertText};
-        variables.forEach(var -> finalInsertText[0] = finalInsertText[0].replace(var.lspSnippetText, "$"));
-
-        String[] splitInsertText = finalInsertText[0].split("\\$");
-        finalInsertText[0] = String.join("", splitInsertText);
-
-        TemplateImpl template = (TemplateImpl) TemplateManager
-                .getInstance(getProject()).createTemplate(finalInsertText[0],
-                "lsp4intellij");
-        template.parseSegments();
-
-        // prevent "smart" indent of next line...
-        template.setToIndent(false);
-
-        final int[] varIndex = {0};
-        variables.forEach(var -> {
-            template.addTextSegment(splitInsertText[varIndex[0]]);
-            template.addVariable(varIndex[0] + "_" + var.variableValue, new TextExpression(var.variableValue),
-                    new TextExpression(var.variableValue), true, false);
-            varIndex[0]++;
-        });
-        // If the snippet text ends with a placeholder, there will be no string segment left to append after the last
-        // variable.
-        if (splitInsertText.length != variables.size()) {
-            template.addTextSegment(splitInsertText[splitInsertText.length - 1]);
-        }
-        template.setInline(true);
-        if (variables.size() > 0) {
-            EditorModificationUtil.moveCaretRelatively(editor, -template.getTemplateText().length());
-        }
-        TemplateManager.getInstance(getProject()).startTemplate(editor, template);
-        signatureHelp();
-    }
-
-    private String convertPlaceHolders(String insertText) {
-        return insertText.replaceAll(SNIPPET_PLACEHOLDER_REGEX, "");
+        completionFeature.prepareAndRunSnippet(insertText);
     }
 
     /**
@@ -1615,26 +1389,4 @@ public class EditorEventManager {
         }
     }
 
-    static class SnippetVariable {
-        String lspSnippetText;
-        int startIndex;
-        int endIndex;
-        String variableValue;
-        String intellijSnippetText;
-
-        SnippetVariable(String text, int start, int end) {
-            this.lspSnippetText = text;
-            this.startIndex = start;
-            this.endIndex = end;
-            this.variableValue = getVariableValue(text);
-        }
-
-        private String getVariableValue(String lspVarSnippet) {
-            if (lspVarSnippet.contains(":")) {
-                lspVarSnippet = lspVarSnippet.replace("\\", "");
-                return lspVarSnippet.substring(lspVarSnippet.indexOf(':') + 1, lspVarSnippet.lastIndexOf('}'));
-            }
-            return " ";
-        }
-    }
 }

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -23,13 +23,11 @@ import com.intellij.lang.annotation.Annotation;
 import com.intellij.lang.annotation.AnnotationHolder;
 import com.intellij.lang.annotation.HighlightSeverity;
 import com.intellij.openapi.actionSystem.ActionManager;
-import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.command.CommandProcessor;
 import com.intellij.openapi.diagnostic.Logger;
 import com.intellij.openapi.editor.Document;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.LogicalPosition;
-import com.intellij.openapi.editor.ScrollType;
 import com.intellij.openapi.editor.SelectionModel;
 import com.intellij.openapi.editor.colors.EditorColors;
 import com.intellij.openapi.editor.event.DocumentEvent;
@@ -42,12 +40,10 @@ import com.intellij.openapi.editor.markup.HighlighterLayer;
 import com.intellij.openapi.editor.markup.HighlighterTargetArea;
 import com.intellij.openapi.fileEditor.FileDocumentManager;
 import com.intellij.openapi.fileEditor.FileEditorManager;
-import com.intellij.openapi.fileEditor.OpenFileDescriptor;
 import com.intellij.openapi.fileTypes.PlainTextLanguage;
 import com.intellij.openapi.project.Project;
 import com.intellij.openapi.util.Pair;
 import com.intellij.openapi.util.TextRange;
-import com.intellij.openapi.vfs.VfsUtil;
 import com.intellij.openapi.vfs.VirtualFile;
 import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
@@ -60,7 +56,6 @@ import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.CompletionItem;
-import org.eclipse.lsp4j.DefinitionParams;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
 import org.eclipse.lsp4j.DocumentFormattingParams;
@@ -69,11 +64,8 @@ import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.InsertReplaceEdit;
 import org.eclipse.lsp4j.Location;
-import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.ReferenceContext;
-import org.eclipse.lsp4j.ReferenceParams;
 import org.eclipse.lsp4j.RenameParams;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentSaveReason;
@@ -89,11 +81,11 @@ import org.wso2.lsp4intellij.client.languageserver.requestmanager.RequestManager
 import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
 import org.wso2.lsp4intellij.contributors.fixes.LSPCodeActionFix;
 import org.wso2.lsp4intellij.contributors.fixes.LSPCommandFix;
-import org.wso2.lsp4intellij.contributors.psi.LSPPsiElement;
 import org.wso2.lsp4intellij.contributors.rename.LSPRenameProcessor;
 import org.wso2.lsp4intellij.features.CompletionFeature;
 import org.wso2.lsp4intellij.features.DiagnosticsFeature;
 import org.wso2.lsp4intellij.features.HoverFeature;
+import org.wso2.lsp4intellij.features.NavigationFeature;
 import org.wso2.lsp4intellij.features.SignatureHelpFeature;
 import org.wso2.lsp4intellij.listeners.LSPCaretListenerImpl;
 import org.wso2.lsp4intellij.requests.WorkspaceEditHandler;
@@ -102,8 +94,6 @@ import org.wso2.lsp4intellij.utils.FileUtils;
 
 import java.awt.Cursor;
 import java.awt.Point;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -116,13 +106,9 @@ import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getIsCtrlDown;
 import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getIsKeyPressed;
 import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.setCtrlRange;
 import static org.wso2.lsp4intellij.requests.Timeouts.CODEACTION;
-import static org.wso2.lsp4intellij.requests.Timeouts.DEFINITION;
 import static org.wso2.lsp4intellij.requests.Timeouts.EXECUTE_COMMAND;
-import static org.wso2.lsp4intellij.requests.Timeouts.REFERENCES;
 import static org.wso2.lsp4intellij.requests.Timeouts.WILLSAVE;
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableReadAction;
-import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableWriteAction;
-import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeAndWait;
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeLater;
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.writeAction;
 import static org.wso2.lsp4intellij.utils.DocumentUtils.toEither;
@@ -167,6 +153,7 @@ public class EditorEventManager {
     private final CompletionFeature completionFeature;
     private final HoverFeature hoverFeature;
     private final SignatureHelpFeature signatureHelpFeature;
+    private final NavigationFeature navigationFeature;
     private AnnotationHolder anonHolder;
     private List<Annotation> annotations = new ArrayList<>();
     private volatile boolean codeActionSyncRequired = false;
@@ -207,6 +194,7 @@ public class EditorEventManager {
         this.hoverFeature = new HoverFeature(editor, wrapper, identifier, hint -> this.currentHint = hint);
         this.signatureHelpFeature = new SignatureHelpFeature(editor, wrapper, identifier, signatureTriggers,
                 hint -> this.currentHint = hint);
+        this.navigationFeature = new NavigationFeature(editor, project, wrapper, identifier);
 
         EditorEventManagerBase.registerManager(this);
 
@@ -362,33 +350,8 @@ public class EditorEventManager {
         }
     }
 
-    /**
-     * Returns the position of the definition given a position in the editor.
-     *
-     * @param position The position
-     * @return The location of the definition
-     */
-    private Location requestDefinition(Position position) {
-        DefinitionParams params = new DefinitionParams(identifier, position);
-        CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>> request =
-                wrapper.getRequestManager().definition(params);
-
-        Either<List<? extends Location>, List<? extends LocationLink>> definition =
-                wrapper.getRequestExecutor().waitFor(request, DEFINITION);
-        if (definition == null) {
-            return null;
-        }
-        if (definition.isLeft() && !definition.getLeft().isEmpty()) {
-            return definition.getLeft().get(0);
-        } else if (definition.isRight() && !definition.getRight().isEmpty()) {
-            var def = definition.getRight().get(0);
-            return new Location(def.getTargetUri(), def.getTargetRange());
-        }
-        return null;
-    }
-
     public Pair<List<PsiElement>, List<VirtualFile>> references(int offset) {
-        return references(offset, false, false);
+        return navigationFeature.references(offset, false, false);
     }
 
     /**
@@ -400,72 +363,7 @@ public class EditorEventManager {
      * @return An array of PsiElement
      */
     public Pair<List<PsiElement>, List<VirtualFile>> references(int offset, boolean getOriginalElement, boolean close) {
-        Position lspPos = DocumentUtils.offsetToLSPPos(editor, offset);
-        TextDocumentIdentifier textDocumentIdentifier = new TextDocumentIdentifier(FileUtils.editorToURIString(editor));
-        ReferenceParams params = new ReferenceParams(
-                textDocumentIdentifier, lspPos, new ReferenceContext(getOriginalElement));
-        params.setPosition(lspPos);
-        params.setTextDocument(identifier);
-        CompletableFuture<List<? extends Location>> request = wrapper.getRequestManager().references(params);
-        List<? extends Location> res = wrapper.getRequestExecutor().waitFor(request, REFERENCES);
-        if (res == null || res.isEmpty()) {
-            return new Pair<>(null, null);
-        }
-        List<VirtualFile> openedEditors = new ArrayList<>();
-        List<PsiElement> elements = new ArrayList<>();
-        res.forEach(l -> {
-            Position start = l.getRange().getStart();
-            Position end = l.getRange().getEnd();
-            String uri = FileUtils.sanitizeURI(l.getUri());
-            VirtualFile file = FileUtils.virtualFileFromURI(uri);
-            Editor curEditor = FileUtils.editorFromUri(uri, project);
-            if (curEditor == null && file != null) {
-                OpenFileDescriptor descriptor = new OpenFileDescriptor(
-                        project, file, start.getLine(), start.getCharacter());
-                curEditor = openEditor(descriptor);
-                if (curEditor != null) {
-                    openedEditors.add(file);
-                }
-            }
-            if (curEditor == null) {
-                LOG.warn("Error occurred in LSP references.");
-                return;
-            }
-            Editor refEditor = curEditor;
-            elements.add(computableReadAction(() -> {
-                int logicalStart = DocumentUtils.lspPosToOffset(refEditor, start);
-                int logicalEnd = DocumentUtils.lspPosToOffset(refEditor, end);
-                String name = refEditor.getDocument().getText(new TextRange(logicalStart, logicalEnd));
-                return new LSPPsiElement(name, project, logicalStart, logicalEnd,
-                        PsiDocumentManager.getInstance(project).getPsiFile(refEditor.getDocument()));
-            }));
-        });
-        if (close && !openedEditors.isEmpty()) {
-            invokeAndWait(() -> writeAction(
-                    () -> openedEditors.forEach(f -> FileEditorManager.getInstance(project).closeFile(f))));
-            openedEditors.clear();
-        }
-        return new Pair<>(elements, openedEditors);
-    }
-
-    /**
-     * Opens an editor for the given descriptor. Runs directly when called on the event dispatch thread;
-     * otherwise the opening is marshaled to the event dispatch thread and this method blocks until done.
-     */
-    private Editor openEditor(OpenFileDescriptor descriptor) {
-        if (ApplicationManager.getApplication().isDispatchThread()) {
-            return computableWriteAction(
-                    () -> FileEditorManager.getInstance(project).openTextEditor(descriptor, false));
-        }
-        if (ApplicationManager.getApplication().isReadAccessAllowed()) {
-            // Blocking on the event dispatch thread while holding the read lock would deadlock.
-            LOG.warn("Cannot open an editor for " + descriptor.getFile() + " from inside a read action");
-            return null;
-        }
-        Editor[] result = new Editor[1];
-        invokeAndWait(() -> result[0] = computableWriteAction(
-                () -> FileEditorManager.getInstance(project).openTextEditor(descriptor, false)));
-        return result[0];
+        return navigationFeature.references(offset, getOriginalElement, close);
     }
 
     /**
@@ -1024,7 +922,7 @@ public class EditorEventManager {
                 editor.xyToLogicalPosition(e.getMouseEvent().getPoint()), editor);
         wrapper.pool(() -> {
             // Resolves the definition off the EDT; range markup and navigation run on the EDT afterwards.
-            Location definitionLocation = requestDefinition(position);
+            Location definitionLocation = navigationFeature.definition(position);
             invokeLater(() -> {
                 if (editor.isDisposed()) {
                     return;
@@ -1057,7 +955,7 @@ public class EditorEventManager {
                         referencesAction.forManagerAndOffset(this, offset);
                     }
                 } else {
-                    gotoLocation(loc);
+                    navigationFeature.gotoLocation(loc);
                 }
 
                 ctrlRange.dispose();
@@ -1067,30 +965,7 @@ public class EditorEventManager {
     }
 
     public void gotoLocation(Location loc) {
-        VirtualFile file = null;
-        try {
-            file = VfsUtil.findFileByURL(new URL(loc.getUri()));
-        } catch (MalformedURLException e1) {
-            LOG.warn("Syntax Exception occurred for uri: " + loc.getUri());
-        }
-        if (file != null) {
-            OpenFileDescriptor descriptor = new OpenFileDescriptor(project, file);
-            VirtualFile finalFile = file;
-            writeAction(() -> {
-                FileEditorManager.getInstance(project).openTextEditor(descriptor, true);
-                Editor srcEditor = FileUtils.editorFromVirtualFile(finalFile, project);
-                if (srcEditor != null) {
-                    Position start = loc.getRange().getStart();
-                    LogicalPosition logicalPos = DocumentUtils.getTabsAwarePosition(srcEditor, start);
-                    if (logicalPos != null) {
-                        srcEditor.getCaretModel().moveToLogicalPosition(logicalPos);
-                        srcEditor.getScrollingModel().scrollTo(logicalPos, ScrollType.CENTER);
-                    }
-                }
-            });
-        } else {
-            LOG.warn("Empty file for " + loc.getUri());
-        }
+        navigationFeature.gotoLocation(loc);
     }
 
     public void requestAndShowCodeActions() {

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -15,7 +15,6 @@
  */
 package org.wso2.lsp4intellij.editor;
 
-import com.intellij.codeInsight.hint.HintManager;
 import com.intellij.codeInsight.lookup.LookupElement;
 import com.intellij.codeInsight.lookup.LookupElementBuilder;
 import com.intellij.lang.Language;
@@ -54,10 +53,6 @@ import com.intellij.psi.PsiDocumentManager;
 import com.intellij.psi.PsiElement;
 import com.intellij.psi.PsiFile;
 import com.intellij.ui.Hint;
-import com.intellij.util.ui.UIUtil;
-import com.vladsch.flexmark.html.HtmlRenderer;
-import com.vladsch.flexmark.parser.Parser;
-import com.vladsch.flexmark.util.data.MutableDataSet;
 import groovy.lang.Tuple3;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.lsp4j.CodeAction;
@@ -72,21 +67,14 @@ import org.eclipse.lsp4j.DocumentFormattingParams;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
 import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.FormattingOptions;
-import org.eclipse.lsp4j.Hover;
-import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.InsertReplaceEdit;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
-import org.eclipse.lsp4j.MarkupContent;
-import org.eclipse.lsp4j.ParameterInformation;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.ReferenceContext;
 import org.eclipse.lsp4j.ReferenceParams;
 import org.eclipse.lsp4j.RenameParams;
-import org.eclipse.lsp4j.SignatureHelp;
-import org.eclipse.lsp4j.SignatureHelpParams;
-import org.eclipse.lsp4j.SignatureInformation;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextDocumentSaveReason;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
@@ -94,7 +82,6 @@ import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WillSaveTextDocumentParams;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
-import org.eclipse.lsp4j.jsonrpc.messages.Tuple;
 import org.jetbrains.annotations.NotNull;
 import org.wso2.lsp4intellij.actions.LSPReferencesAction;
 import org.wso2.lsp4intellij.client.languageserver.ServerOptions;
@@ -106,14 +93,14 @@ import org.wso2.lsp4intellij.contributors.psi.LSPPsiElement;
 import org.wso2.lsp4intellij.contributors.rename.LSPRenameProcessor;
 import org.wso2.lsp4intellij.features.CompletionFeature;
 import org.wso2.lsp4intellij.features.DiagnosticsFeature;
+import org.wso2.lsp4intellij.features.HoverFeature;
+import org.wso2.lsp4intellij.features.SignatureHelpFeature;
 import org.wso2.lsp4intellij.listeners.LSPCaretListenerImpl;
-import org.wso2.lsp4intellij.requests.HoverHandler;
 import org.wso2.lsp4intellij.requests.WorkspaceEditHandler;
 import org.wso2.lsp4intellij.utils.DocumentUtils;
 import org.wso2.lsp4intellij.utils.FileUtils;
 
 import java.awt.Cursor;
-import java.awt.Font;
 import java.awt.Point;
 import java.net.MalformedURLException;
 import java.net.URL;
@@ -131,9 +118,7 @@ import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.setCtrlRange;
 import static org.wso2.lsp4intellij.requests.Timeouts.CODEACTION;
 import static org.wso2.lsp4intellij.requests.Timeouts.DEFINITION;
 import static org.wso2.lsp4intellij.requests.Timeouts.EXECUTE_COMMAND;
-import static org.wso2.lsp4intellij.requests.Timeouts.HOVER;
 import static org.wso2.lsp4intellij.requests.Timeouts.REFERENCES;
-import static org.wso2.lsp4intellij.requests.Timeouts.SIGNATURE;
 import static org.wso2.lsp4intellij.requests.Timeouts.WILLSAVE;
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableReadAction;
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableWriteAction;
@@ -169,7 +154,6 @@ public class EditorEventManager {
     private LSPCaretListenerImpl caretListener;
 
     public List<String> completionTriggers;
-    private List<String> signatureTriggers;
     private TextDocumentSyncKind syncKind;
     private volatile boolean needSave = false;
     private long predTime = -1L;
@@ -181,6 +165,8 @@ public class EditorEventManager {
 
     private final DiagnosticsFeature diagnosticsFeature;
     private final CompletionFeature completionFeature;
+    private final HoverFeature hoverFeature;
+    private final SignatureHelpFeature signatureHelpFeature;
     private AnnotationHolder anonHolder;
     private List<Annotation> annotations = new ArrayList<>();
     private volatile boolean codeActionSyncRequired = false;
@@ -209,7 +195,7 @@ public class EditorEventManager {
                 serverOptions.completionOptions.getTriggerCharacters() :
                 new ArrayList<>();
 
-        this.signatureTriggers = (serverOptions.signatureHelpOptions != null
+        List<String> signatureTriggers = (serverOptions.signatureHelpOptions != null
                 && serverOptions.signatureHelpOptions.getTriggerCharacters() != null) ?
                 serverOptions.signatureHelpOptions.getTriggerCharacters() :
                 new ArrayList<>();
@@ -218,6 +204,9 @@ public class EditorEventManager {
         this.diagnosticsFeature = new DiagnosticsFeature(editor, project);
         this.completionFeature = new CompletionFeature(editor, project, wrapper, identifier, completionTriggers,
                 this::applyEdit, this::executeCommands, this::signatureHelp);
+        this.hoverFeature = new HoverFeature(editor, wrapper, identifier, hint -> this.currentHint = hint);
+        this.signatureHelpFeature = new SignatureHelpFeature(editor, wrapper, identifier, signatureTriggers,
+                hint -> this.currentHint = hint);
 
         EditorEventManagerBase.registerManager(this);
 
@@ -247,9 +236,7 @@ public class EditorEventManager {
      * @param c The character just typed
      */
     public void characterTyped(char c) {
-        if (signatureTriggers.contains(Character.toString(c))) {
-            signatureHelp();
-        }
+        signatureHelpFeature.characterTyped(c);
     }
 
     /**
@@ -311,7 +298,7 @@ public class EditorEventManager {
                         getCtrlRange().dispose();
                     }
                     setCtrlRange(null);
-                    wrapper.pool(() -> requestAndShowDoc(lPos, e.getMouseEvent().getPoint()));
+                    wrapper.pool(() -> hoverFeature.showHoverAt(lPos, e.getMouseEvent().getPoint()));
                 } else if (getCtrlRange().definitionContainsOffset(offset)) {
                     createAndShowEditorHint(editor, "Click to show usages", editor.offsetToXY(offset));
                 } else {
@@ -561,88 +548,7 @@ public class EditorEventManager {
      */
     @SuppressWarnings("WeakerAccess")
     public void signatureHelp() {
-        if (editor.isDisposed()) {
-            return;
-        }
-        LogicalPosition lPos = editor.getCaretModel().getCurrentCaret().getLogicalPosition();
-        Point point = editor.logicalPositionToXY(lPos);
-        SignatureHelpParams params = new SignatureHelpParams(identifier, DocumentUtils.logicalToLSPPos(lPos, editor));
-        wrapper.pool(() -> {
-            CompletableFuture<SignatureHelp> future = wrapper.getRequestManager().signatureHelp(params);
-            SignatureHelp signatureResp = wrapper.getRequestExecutor().waitFor(future, SIGNATURE);
-            if (signatureResp == null) {
-                return;
-            }
-            try {
-                List<SignatureInformation> signatures = signatureResp.getSignatures();
-                if (signatures == null || signatures.isEmpty()) {
-                    return;
-                }
-                int activeSignatureIndex = signatureResp.getActiveSignature();
-                int activeParameterIndex = signatureResp.getActiveParameter();
-
-                SignatureInformation activeSignature = signatures.get(activeSignatureIndex);
-                String activeParameter =
-                        activeSignature.getParameters().size() > activeParameterIndex
-                        ? extractLabel(activeSignature,
-                                activeSignature.getParameters()
-                                        .get(activeParameterIndex).getLabel())
-                        : "";
-                Either<String, MarkupContent> signatureDescription =
-                        activeSignature.getDocumentation();
-                StringBuilder builder = new StringBuilder();
-                Font font = UIUtil.getLabelFont();
-                MutableDataSet options = new MutableDataSet();
-                Parser parser = Parser.builder(options).build();
-                HtmlRenderer renderer = HtmlRenderer.builder(options).build();
-                builder.append("<html>");
-                builder.append(UIUtil.getCssFontDeclaration(font));
-                List<String> result = new ArrayList<>();
-                if (!signatures.isEmpty() && signatures.get(activeSignatureIndex).getParameters() != null) {
-                    for (ParameterInformation param : signatures.get(activeSignatureIndex).getParameters()) {
-                        Either<String, MarkupContent> doc = param.getDocumentation();
-                        if (doc.isRight()) {
-                            result.add(renderer.render(parser.parse(doc.getRight().getValue())));
-                        }
-                    }
-                }
-                if (signatureDescription == null) {
-                    builder.append("<code>").append(signatures.get(activeSignatureIndex).getLabel().
-                            replace(" " + activeParameter, String.format("<font color=\"orange\"> %s</font>",
-                                    activeParameter))).append("</code>");
-                } else if (signatureDescription.isLeft()) {
-                    String description = signatureDescription.getLeft().replace(System.lineSeparator(), "<br />");
-                    builder.append("<code>").append(signatures.get(activeSignatureIndex).getLabel()
-                            .replace(" " + activeParameter, String.format("<font color=\"orange\"> %s</font>",
-                                    activeParameter))).append("</code>");
-                    builder.append("<p>").append(description).append("</p>");
-                } else if (signatureDescription.isRight()) {
-                    String string = renderer.render(parser.parse(signatures.get(activeSignatureIndex).getLabel()));
-                    builder.append("<code>").append(string).append("</code>");
-                }
-                if (!result.isEmpty()) {
-                    builder.append("<div>").append(String.join("\n", result)).append("</div>");
-                }
-                builder.append("</html>");
-                invokeLater(() -> currentHint = createAndShowEditorHint(
-                        editor, builder.toString(), point,
-                        HintManager.UNDER, HintManager.HIDE_BY_OTHER_HINT));
-
-            } catch (Exception e) {
-                LOG.warn("Internal error occurred when processing signature help");
-            }
-        });
-    }
-
-    private String extractLabel(SignatureInformation signatureInformation,
-            Either<String, Tuple.Two<Integer, Integer>> label) {
-        if (label.isLeft()) {
-            return label.getLeft();
-        } else if (label.isRight()) {
-            return signatureInformation.getLabel().substring(label.getRight().getFirst(), label.getRight().getSecond());
-        } else {
-            return "";
-        }
+        signatureHelpFeature.signatureHelp();
     }
 
     /**
@@ -763,51 +669,10 @@ public class EditorEventManager {
             LogicalPosition caretPos = editor.getCaretModel().getLogicalPosition();
             Point pointPos = editor.logicalPositionToXY(caretPos);
             long currentTime = System.nanoTime();
-            wrapper.pool(() -> requestAndShowDoc(caretPos, pointPos));
+            wrapper.pool(() -> hoverFeature.showHoverAt(caretPos, pointPos));
             predTime = currentTime;
         } else {
             LOG.warn("Not same editor!");
-        }
-    }
-
-    /**
-     * Gets the hover request and shows it.
-     *
-     * @param editorPos The editor position
-     * @param point     The point at which to show the hint
-     */
-    private void requestAndShowDoc(LogicalPosition editorPos, Point point) {
-        Position serverPos = computableReadAction(() -> DocumentUtils.logicalToLSPPos(editorPos, editor));
-        CompletableFuture<Hover> request = wrapper.getRequestManager().hover(new HoverParams(identifier, serverPos));
-        if (request == null) {
-            return;
-        }
-        Hover hover = wrapper.getRequestExecutor().waitFor(request, HOVER);
-        if (hover == null) {
-            LOG.debug(String.format("Hover is null for file %s and pos (%d;%d)", identifier.getUri(),
-                    serverPos.getLine(), serverPos.getCharacter()));
-            return;
-        }
-
-        String string = HoverHandler.getHoverString(hover);
-        if (StringUtils.isEmpty(string)) {
-            LOG.warn(String.format("Hover string returned is empty for file %s and pos (%d;%d)",
-                    identifier.getUri(), serverPos.getLine(), serverPos.getCharacter()));
-            return;
-        }
-
-        if (getIsCtrlDown()) {
-            invokeLater(() -> {
-                if (!editor.isDisposed()) {
-                    currentHint = createAndShowEditorHint(editor, string, point, HintManager.HIDE_BY_OTHER_HINT);
-                }
-            });
-        } else {
-            invokeLater(() -> {
-                if (!editor.isDisposed()) {
-                    currentHint = createAndShowEditorHint(editor, string, point);
-                }
-            });
         }
     }
 

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -72,11 +72,14 @@ import org.wso2.lsp4intellij.client.languageserver.requestmanager.RequestManager
 import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
 import org.wso2.lsp4intellij.contributors.fixes.LSPCodeActionFix;
 import org.wso2.lsp4intellij.features.CodeActionFeature;
+import org.wso2.lsp4intellij.features.CodeActionOverrides;
 import org.wso2.lsp4intellij.features.CompletionFeature;
+import org.wso2.lsp4intellij.features.CompletionOverrides;
 import org.wso2.lsp4intellij.features.DiagnosticsFeature;
 import org.wso2.lsp4intellij.features.FormattingFeature;
 import org.wso2.lsp4intellij.features.HoverFeature;
 import org.wso2.lsp4intellij.features.NavigationFeature;
+import org.wso2.lsp4intellij.features.ReferenceLookup;
 import org.wso2.lsp4intellij.features.RenameFeature;
 import org.wso2.lsp4intellij.features.SignatureHelpFeature;
 import org.wso2.lsp4intellij.listeners.LSPCaretListenerImpl;
@@ -112,7 +115,14 @@ import static org.wso2.lsp4intellij.utils.GUIUtils.createAndShowEditorHint;
  * serverOptions       The options of the server regarding completion, signatureHelp, syncKind, etc
  * wrapper             The corresponding LanguageServerWrapper
  */
-public class EditorEventManager {
+public class EditorEventManager implements CompletionOverrides, CodeActionOverrides, ReferenceLookup {
+
+    /**
+     * @deprecated moved to {@link CompletionFeature#SNIPPET_PLACEHOLDER_REGEX}. Kept here so plugins
+     *         recompiling against this class continue to resolve it.
+     */
+    @Deprecated
+    public static final String SNIPPET_PLACEHOLDER_REGEX = CompletionFeature.SNIPPET_PLACEHOLDER_REGEX;
 
     public final DocumentEventManager documentEventManager;
     protected static final Logger LOG = Logger.getInstance(EditorEventManager.class);
@@ -172,13 +182,13 @@ public class EditorEventManager {
         this.project = editor.getProject();
         this.diagnosticsFeature = new DiagnosticsFeature(editor, project);
         this.completionFeature = new CompletionFeature(editor, project, wrapper, identifier, completionTriggers,
-                this::applyEdit, this::executeCommands, this::signatureHelp);
+                this::applyEdit, this::executeCommands, this::signatureHelp, this);
         this.hoverFeature = new HoverFeature(editor, wrapper, identifier, hint -> this.currentHint = hint);
         this.signatureHelpFeature = new SignatureHelpFeature(editor, wrapper, identifier, signatureTriggers,
                 hint -> this.currentHint = hint);
         this.navigationFeature = new NavigationFeature(editor, project, wrapper, identifier);
-        this.codeActionFeature = new CodeActionFeature(editor, wrapper, identifier, diagnosticsFeature);
-        this.renameFeature = new RenameFeature(editor, project, wrapper, identifier, navigationFeature);
+        this.codeActionFeature = new CodeActionFeature(editor, wrapper, identifier, diagnosticsFeature, this);
+        this.renameFeature = new RenameFeature(editor, project, wrapper, identifier, this);
         this.formattingFeature = new FormattingFeature(editor, wrapper, identifier, this::applyEdit);
 
         EditorEventManagerBase.registerManager(this);

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -16,7 +16,6 @@
 package org.wso2.lsp4intellij.editor;
 
 import com.intellij.codeInsight.completion.InsertionContext;
-import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
 import com.intellij.codeInsight.hint.HintManager;
 import com.intellij.codeInsight.lookup.AutoCompletionPolicy;
 import com.intellij.codeInsight.lookup.LookupElement;
@@ -116,6 +115,7 @@ import org.wso2.lsp4intellij.contributors.fixes.LSPCommandFix;
 import org.wso2.lsp4intellij.contributors.icon.LSPIconProvider;
 import org.wso2.lsp4intellij.contributors.psi.LSPPsiElement;
 import org.wso2.lsp4intellij.contributors.rename.LSPRenameProcessor;
+import org.wso2.lsp4intellij.features.DiagnosticsFeature;
 import org.wso2.lsp4intellij.listeners.LSPCaretListenerImpl;
 import org.wso2.lsp4intellij.requests.HoverHandler;
 import org.wso2.lsp4intellij.requests.WorkspaceEditHandler;
@@ -196,10 +196,9 @@ public class EditorEventManager {
     private boolean mouseInEditor = true;
     private Hint currentHint;
 
-    private final List<Diagnostic> diagnostics = new ArrayList<>();
+    private final DiagnosticsFeature diagnosticsFeature;
     private AnnotationHolder anonHolder;
     private List<Annotation> annotations = new ArrayList<>();
-    private volatile boolean diagnosticSyncRequired = true;
     private volatile boolean codeActionSyncRequired = false;
 
     private static final long CTRL_THRESH = EditorSettingsExternalizable.getInstance().getTooltipsDelay() * 1000000;
@@ -234,6 +233,7 @@ public class EditorEventManager {
                 new ArrayList<>();
 
         this.project = editor.getProject();
+        this.diagnosticsFeature = new DiagnosticsFeature(editor, project);
 
         EditorEventManagerBase.registerManager(this);
 
@@ -500,9 +500,8 @@ public class EditorEventManager {
     /**
      * @return The current diagnostics highlights
      */
-    public synchronized List<Diagnostic> getDiagnostics() {
-        this.diagnosticSyncRequired = false;
-        return this.diagnostics;
+    public List<Diagnostic> getDiagnostics() {
+        return diagnosticsFeature.diagnostics();
     }
 
     /**
@@ -521,8 +520,8 @@ public class EditorEventManager {
         this.anonHolder = holder;
     }
 
-    public synchronized boolean isDiagnosticSyncRequired() {
-        return this.diagnosticSyncRequired;
+    public boolean isDiagnosticSyncRequired() {
+        return diagnosticsFeature.isSyncRequired();
     }
 
     public synchronized boolean isCodeActionSyncRequired() {
@@ -535,20 +534,7 @@ public class EditorEventManager {
      * @param diagnostics The diagnostics to apply from the server
      */
     public void diagnostics(List<Diagnostic> diagnostics) {
-
-        // If both of the old diagnostics and the received diagnostics are empty, we can simply return without
-        // re-triggering the annotator.
-        if (editor.isDisposed() || (this.diagnostics.isEmpty() && diagnostics.isEmpty())) {
-            return;
-        }
-
-        synchronized (this.diagnostics) {
-            this.diagnostics.clear();
-            this.diagnostics.addAll(diagnostics);
-            diagnosticSyncRequired = true;
-            // Triggers force full DaemonCodeAnalyzer execution.
-            updateErrorAnnotations();
-        }
+        diagnosticsFeature.publish(diagnostics);
     }
 
     /**
@@ -567,15 +553,13 @@ public class EditorEventManager {
 
         // Calculates the diagnostic context.
         List<Diagnostic> diagnosticContext = new ArrayList<>();
-        synchronized (this.diagnostics) {
-            diagnostics.forEach(diagnostic -> {
-                int startOffset = DocumentUtils.lspPosToOffset(editor, diagnostic.getRange().getStart());
-                int endOffset = DocumentUtils.lspPosToOffset(editor, diagnostic.getRange().getEnd());
-                if (offset >= startOffset && offset <= endOffset) {
-                    diagnosticContext.add(diagnostic);
-                }
-            });
-        }
+        diagnosticsFeature.withDiagnostics(diags -> diags.forEach(diagnostic -> {
+            int startOffset = DocumentUtils.lspPosToOffset(editor, diagnostic.getRange().getStart());
+            int endOffset = DocumentUtils.lspPosToOffset(editor, diagnostic.getRange().getEnd());
+            if (offset >= startOffset && offset <= endOffset) {
+                diagnosticContext.add(diagnostic);
+            }
+        }));
 
         CodeActionContext context = new CodeActionContext(diagnosticContext);
         params.setContext(context);
@@ -1587,24 +1571,8 @@ public class EditorEventManager {
         // If code actions are updated, forcefully triggers the inspection tool.
         if (codeActionSyncRequired) {
             // double-delay the update to ensure that the code analyzer finishes.
-            invokeLater(this::updateErrorAnnotations);
+            invokeLater(diagnosticsFeature::restartDaemonCodeAnalyzer);
         }
-    }
-
-    /**
-     * Triggers force full DaemonCodeAnalyzer execution.
-     */
-    private void updateErrorAnnotations() {
-        computableReadAction(() -> {
-            final PsiFile file = PsiDocumentManager.getInstance(project)
-                    .getCachedPsiFile(editor.getDocument());
-            if (file == null) {
-                return null;
-            }
-            LOG.debug("Triggering force full DaemonCodeAnalyzer execution.");
-            DaemonCodeAnalyzer.getInstance(project).restart(file);
-            return null;
-        });
     }
 
     public List<Tuple3<HighlightSeverity, TextRange, LSPCodeActionFix>> getSilentAnnotations() {
@@ -1614,7 +1582,7 @@ public class EditorEventManager {
     public void triggerIntentionActions() {
         if (isTriggerIntentionActions) {
             isTriggerIntentionActions = false;
-            updateErrorAnnotations();
+            diagnosticsFeature.restartDaemonCodeAnalyzer();
         }
     }
 

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -52,15 +52,12 @@ import com.intellij.ui.Hint;
 import groovy.lang.Tuple3;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.lsp4j.CodeAction;
-import org.eclipse.lsp4j.CodeActionContext;
-import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.Command;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DidSaveTextDocumentParams;
 import org.eclipse.lsp4j.DocumentFormattingParams;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
-import org.eclipse.lsp4j.ExecuteCommandParams;
 import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.InsertReplaceEdit;
 import org.eclipse.lsp4j.Location;
@@ -80,8 +77,8 @@ import org.wso2.lsp4intellij.client.languageserver.ServerOptions;
 import org.wso2.lsp4intellij.client.languageserver.requestmanager.RequestManager;
 import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
 import org.wso2.lsp4intellij.contributors.fixes.LSPCodeActionFix;
-import org.wso2.lsp4intellij.contributors.fixes.LSPCommandFix;
 import org.wso2.lsp4intellij.contributors.rename.LSPRenameProcessor;
+import org.wso2.lsp4intellij.features.CodeActionFeature;
 import org.wso2.lsp4intellij.features.CompletionFeature;
 import org.wso2.lsp4intellij.features.DiagnosticsFeature;
 import org.wso2.lsp4intellij.features.HoverFeature;
@@ -98,15 +95,12 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 
 import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getCtrlRange;
 import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getIsCtrlDown;
 import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getIsKeyPressed;
 import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.setCtrlRange;
-import static org.wso2.lsp4intellij.requests.Timeouts.CODEACTION;
-import static org.wso2.lsp4intellij.requests.Timeouts.EXECUTE_COMMAND;
 import static org.wso2.lsp4intellij.requests.Timeouts.WILLSAVE;
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableReadAction;
 import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeLater;
@@ -154,15 +148,9 @@ public class EditorEventManager {
     private final HoverFeature hoverFeature;
     private final SignatureHelpFeature signatureHelpFeature;
     private final NavigationFeature navigationFeature;
-    private AnnotationHolder anonHolder;
-    private List<Annotation> annotations = new ArrayList<>();
-    private volatile boolean codeActionSyncRequired = false;
+    private final CodeActionFeature codeActionFeature;
 
     private static final long CTRL_THRESH = EditorSettingsExternalizable.getInstance().getTooltipsDelay() * 1000000;
-
-    private final List<Tuple3<HighlightSeverity, TextRange, LSPCodeActionFix>> silentAnnotations = new ArrayList<>();
-
-    private boolean isTriggerIntentionActions = false;
 
     //Todo - Revisit arguments order and add remaining listeners
     public EditorEventManager(Editor editor, DocumentListener documentListener, EditorMouseListener mouseListener,
@@ -195,6 +183,7 @@ public class EditorEventManager {
         this.signatureHelpFeature = new SignatureHelpFeature(editor, wrapper, identifier, signatureTriggers,
                 hint -> this.currentHint = hint);
         this.navigationFeature = new NavigationFeature(editor, project, wrapper, identifier);
+        this.codeActionFeature = new CodeActionFeature(editor, wrapper, identifier, diagnosticsFeature);
 
         EditorEventManagerBase.registerManager(this);
 
@@ -376,25 +365,24 @@ public class EditorEventManager {
     /**
      * @return The current diagnostic annotations
      */
-    public synchronized List<Annotation> getAnnotations() {
-        this.codeActionSyncRequired = false;
-        return this.annotations;
+    public List<Annotation> getAnnotations() {
+        return codeActionFeature.getAnnotations();
     }
 
-    public synchronized void setAnnotations(List<Annotation> annotations) {
-        this.annotations = annotations;
+    public void setAnnotations(List<Annotation> annotations) {
+        codeActionFeature.setAnnotations(annotations);
     }
 
-    public synchronized void setAnonHolder(AnnotationHolder holder) {
-        this.anonHolder = holder;
+    public void setAnonHolder(AnnotationHolder holder) {
+        codeActionFeature.setAnonHolder(holder);
     }
 
     public boolean isDiagnosticSyncRequired() {
         return diagnosticsFeature.isSyncRequired();
     }
 
-    public synchronized boolean isCodeActionSyncRequired() {
-        return this.codeActionSyncRequired;
+    public boolean isCodeActionSyncRequired() {
+        return codeActionFeature.isCodeActionSyncRequired();
     }
 
     /**
@@ -414,31 +402,11 @@ public class EditorEventManager {
      */
     @SuppressWarnings("WeakerAccess")
     public List<Either<Command, CodeAction>> codeAction(int offset) {
-        CodeActionParams params = new CodeActionParams();
-        params.setTextDocument(identifier);
-        Range range = new Range(DocumentUtils.offsetToLSPPos(editor, offset),
-                DocumentUtils.offsetToLSPPos(editor, offset));
-        params.setRange(range);
-
-        // Calculates the diagnostic context.
-        List<Diagnostic> diagnosticContext = new ArrayList<>();
-        diagnosticsFeature.withDiagnostics(diags -> diags.forEach(diagnostic -> {
-            int startOffset = DocumentUtils.lspPosToOffset(editor, diagnostic.getRange().getStart());
-            int endOffset = DocumentUtils.lspPosToOffset(editor, diagnostic.getRange().getEnd());
-            if (offset >= startOffset && offset <= endOffset) {
-                diagnosticContext.add(diagnostic);
-            }
-        }));
-
-        CodeActionContext context = new CodeActionContext(diagnosticContext);
-        params.setContext(context);
-        CompletableFuture<List<Either<Command, CodeAction>>> future = wrapper.getRequestManager().codeAction(params);
-        return wrapper.getRequestExecutor().waitFor(future, CODEACTION);
+        return codeActionFeature.codeAction(offset);
     }
 
     public CodeAction resolvedCodeAction(CodeAction codeAction) {
-        CompletableFuture<CodeAction> future = wrapper.getRequestManager().resolveCodeAction(codeAction);
-        return wrapper.getRequestExecutor().waitFor(future, CODEACTION);
+        return codeActionFeature.resolvedCodeAction(codeAction);
     }
 
     /**
@@ -767,18 +735,7 @@ public class EditorEventManager {
      * @param commands The commands to execute
      */
     public void executeCommands(List<Command> commands) {
-        wrapper.pool(() -> {
-            if (editor.isDisposed()) {
-                return;
-            }
-            commands.stream().map(c -> {
-                ExecuteCommandParams params = new ExecuteCommandParams();
-                params.setArguments(c.getArguments());
-                params.setCommand(c.getCommand());
-                return wrapper.getRequestManager().executeCommand(params);
-            }).filter(Objects::nonNull).forEach(f ->
-                    wrapper.getRequestExecutor().waitFor(f, EXECUTE_COMMAND));
-        });
+        codeActionFeature.executeCommands(commands);
     }
 
     private void saveDocument() {
@@ -843,7 +800,7 @@ public class EditorEventManager {
             return;
         }
         if (event.getDocument() == editor.getDocument()) {
-            silentAnnotations.clear();
+            codeActionFeature.getSilentAnnotations().clear();
             documentEventManager.documentChanged(event);
         } else {
             LOG.error("Wrong document for the EditorEventManager");
@@ -969,135 +926,15 @@ public class EditorEventManager {
     }
 
     public void requestAndShowCodeActions() {
-        wrapper.pool(() -> {
-            if (editor.isDisposed()) {
-                return;
-            }
-
-            // Sends the code action request and resolves incomplete code actions while off the EDT;
-            // only the annotation bookkeeping runs on the EDT.
-            int caretPos = computableReadAction(() -> editor.getCaretModel().getCurrentCaret().getOffset());
-            List<Either<Command, CodeAction>> codeActionResp = codeAction(caretPos);
-            if (codeActionResp == null || codeActionResp.isEmpty()) {
-                return;
-            }
-            List<Either<Command, CodeAction>> codeActions = new ArrayList<>();
-            for (Either<Command, CodeAction> element : codeActionResp) {
-                if (element == null) {
-                    continue;
-                }
-                if (element.isRight() && element.getRight().getEdit() == null) {
-                    CodeAction resolved = resolvedCodeAction(element.getRight());
-                    if (resolved != null && resolved.getEdit() != null) {
-                        codeActions.add(Either.forRight(resolved));
-                        continue;
-                    }
-                }
-                codeActions.add(element);
-            }
-            invokeLater(() -> showCodeActions(caretPos, codeActions));
-        });
-    }
-
-    private void showCodeActions(int caretPos, List<Either<Command, CodeAction>> codeActions) {
-        if (editor.isDisposed()) {
-            return;
-        }
-        if (annotations == null) {
-            annotations = new ArrayList<>();
-        }
-
-        codeActions.forEach(element -> {
-                if (element.isLeft()) {
-                    Command command = element.getLeft();
-                    Annotation annotWithCodeAction = null;
-                    for (Annotation annotation : annotations) {
-                        int start = annotation.getStartOffset();
-                        int end = annotation.getEndOffset();
-                        if (start <= caretPos && end >= caretPos) {
-                            if (annotation.getQuickFixes() == null || annotation.getQuickFixes().isEmpty()) {
-                                isTriggerIntentionActions = true;
-                            }
-                            annotation.registerFix(new LSPCommandFix(FileUtils.editorToURIString(editor), command),
-                                    new TextRange(start, end));
-                            codeActionSyncRequired = true;
-                            annotWithCodeAction = annotation;
-                            break;
-                        }
-                    }
-                    if (annotWithCodeAction != null) {
-                        annotations.remove(annotWithCodeAction);
-                        annotations.add(0, annotWithCodeAction);
-                    }
-                } else if (element.isRight()) {
-                    CodeAction codeAction = element.getRight();
-                    List<Diagnostic> diagnosticContext = codeAction.getDiagnostics();
-                    Annotation annotWithCodeAction = null;
-                    for (Annotation annotation : annotations) {
-                        int start = annotation.getStartOffset();
-                        int end = annotation.getEndOffset();
-                        if (start <= caretPos && end >= caretPos) {
-                            if (annotation.getQuickFixes() == null || annotation.getQuickFixes().isEmpty()) {
-                                isTriggerIntentionActions = true;
-                            }
-                            annotation.registerFix(new LSPCodeActionFix(FileUtils.editorToURIString(editor),
-                                    codeAction), new TextRange(start, end));
-                            codeActionSyncRequired = true;
-                            annotWithCodeAction = annotation;
-                            break;
-                        }
-                    }
-                    if (annotWithCodeAction != null) {
-                        annotations.remove(annotWithCodeAction);
-                        annotations.add(0, annotWithCodeAction);
-                    }
-
-                    // If the code actions does not have a diagnostics context, creates an intention action for
-                    // the current line.
-                    if ((diagnosticContext == null || diagnosticContext.isEmpty())
-                            && anonHolder != null && !codeActionSyncRequired) {
-                        // Calculates text range of the current line.
-                        int line = editor.getCaretModel().getCurrentCaret().getLogicalPosition().line;
-                        int startOffset = editor.getDocument().getLineStartOffset(line);
-                        int endOffset = editor.getDocument().getLineEndOffset(line);
-                        TextRange range = new TextRange(startOffset, endOffset);
-                        CodeAction finalCodeAction = codeAction;
-                        boolean found = silentAnnotations.stream()
-                                .anyMatch(silentAnnotation ->
-                                        silentAnnotation.getSecond().getStartOffset() == startOffset &&
-                                        silentAnnotation.getSecond().getEndOffset() == endOffset &&
-                                        silentAnnotation.getThird().getText().equals(finalCodeAction.getTitle())
-                                 );
-                        if (!found) {
-                            Tuple3<HighlightSeverity, TextRange, LSPCodeActionFix> sAnnotation =
-                                    new Tuple3<>(
-                                            HighlightSeverity.INFORMATION,
-                                            range,
-                                            new LSPCodeActionFix(FileUtils.editorToURIString(editor), codeAction)
-                                    );
-                            silentAnnotations.add(sAnnotation);
-                            isTriggerIntentionActions = true;
-                        }
-                        codeActionSyncRequired = true;
-                    }
-                }
-        });
-        // If code actions are updated, forcefully triggers the inspection tool.
-        if (codeActionSyncRequired) {
-            // double-delay the update to ensure that the code analyzer finishes.
-            invokeLater(diagnosticsFeature::restartDaemonCodeAnalyzer);
-        }
+        codeActionFeature.requestAndShowCodeActions();
     }
 
     public List<Tuple3<HighlightSeverity, TextRange, LSPCodeActionFix>> getSilentAnnotations() {
-        return silentAnnotations;
+        return codeActionFeature.getSilentAnnotations();
     }
 
     public void triggerIntentionActions() {
-        if (isTriggerIntentionActions) {
-            isTriggerIntentionActions = false;
-            diagnosticsFeature.restartDaemonCodeAnalyzer();
-        }
+        codeActionFeature.triggerIntentionActions();
     }
 
     public static class LSPTextEdit implements Comparable<LSPTextEdit> {

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -119,9 +119,12 @@ public class EditorEventManager implements CompletionOverrides, CodeActionOverri
 
     /**
      * @deprecated moved to {@link CompletionFeature#SNIPPET_PLACEHOLDER_REGEX}. Kept here so plugins
-     *         recompiling against this class continue to resolve it.
+     *         recompiling against this class continue to resolve it; read it from
+     *         {@code CompletionFeature} instead. No {@code since} is declared because the project
+     *         version is derived from the git tag at build time, so the release this lands in is not
+     *         known here.
      */
-    @Deprecated
+    @Deprecated(forRemoval = true)
     public static final String SNIPPET_PLACEHOLDER_REGEX = CompletionFeature.SNIPPET_PLACEHOLDER_REGEX;
 
     public final DocumentEventManager documentEventManager;

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManager.java
@@ -890,7 +890,7 @@ public class EditorEventManager implements CompletionOverrides, CodeActionOverri
 
         @Override
         public int compareTo(@NotNull LSPTextEdit te) {
-            return te.getStartOffset() - getStartOffset();
+            return Integer.compare(te.getStartOffset(), getStartOffset());
         }
     }
 

--- a/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
+++ b/src/main/java/org/wso2/lsp4intellij/editor/EditorEventManagerBase.java
@@ -68,7 +68,8 @@ public class EditorEventManagerBase {
         EditorEventManagerBase.ctrlRange = ctrlRange;
     }
 
-    static synchronized boolean getIsCtrlDown() {
+    // Public: HoverFeature (a different package) also reads this to decide how to show a hover hint.
+    public static synchronized boolean getIsCtrlDown() {
         return isCtrlDown;
     }
 

--- a/src/main/java/org/wso2/lsp4intellij/features/CodeActionFeature.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/CodeActionFeature.java
@@ -1,0 +1,292 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.features;
+
+import com.intellij.lang.annotation.Annotation;
+import com.intellij.lang.annotation.AnnotationHolder;
+import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.util.TextRange;
+import groovy.lang.Tuple3;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionContext;
+import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
+import org.wso2.lsp4intellij.contributors.fixes.LSPCodeActionFix;
+import org.wso2.lsp4intellij.contributors.fixes.LSPCommandFix;
+import org.wso2.lsp4intellij.utils.DocumentUtils;
+import org.wso2.lsp4intellij.utils.FileUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+
+import static org.wso2.lsp4intellij.requests.Timeouts.CODEACTION;
+import static org.wso2.lsp4intellij.requests.Timeouts.EXECUTE_COMMAND;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableReadAction;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeLater;
+
+/**
+ * Requests code actions, resolves incomplete ones, registers them as quick fixes on the
+ * annotations the diagnostics pass already created, and executes LSP commands (used both by code
+ * actions and by completion items that carry a command).
+ *
+ * <p>Extracted from {@code EditorEventManager} as part of the feature-layer decomposition
+ * (ARCHITECTURE.md section 2.4); {@code EditorEventManager} composes one instance per editor and
+ * keeps every method here that {@code LSPAnnotator}, {@code LSPCommandFix}/{@code LSPCodeActionFix},
+ * or {@code LSPCaretListenerImpl} call directly as a public delegating facade with an unchanged
+ * signature.
+ *
+ * <p>Depends directly on this editor's {@link DiagnosticsFeature} (to read the diagnostic context
+ * for a code-action request, and to force the re-annotation a newly attached fix needs) rather
+ * than an injected callback — the two features are peers composed together, not a stand-in for the
+ * {@code EditorContext} object other extractions in this decomposition needed one for.
+ */
+public final class CodeActionFeature {
+
+    private final Editor editor;
+    private final LanguageServerWrapper wrapper;
+    private final TextDocumentIdentifier identifier;
+    private final DiagnosticsFeature diagnosticsFeature;
+
+    private List<Annotation> annotations = new ArrayList<>();
+    private AnnotationHolder anonHolder;
+    private volatile boolean codeActionSyncRequired = false;
+    private boolean isTriggerIntentionActions = false;
+    private final List<Tuple3<HighlightSeverity, TextRange, LSPCodeActionFix>> silentAnnotations = new ArrayList<>();
+
+    public CodeActionFeature(Editor editor, LanguageServerWrapper wrapper, TextDocumentIdentifier identifier,
+            DiagnosticsFeature diagnosticsFeature) {
+        this.editor = editor;
+        this.wrapper = wrapper;
+        this.identifier = identifier;
+        this.diagnosticsFeature = diagnosticsFeature;
+    }
+
+    /**
+     * @return The current diagnostic annotations
+     */
+    public synchronized List<Annotation> getAnnotations() {
+        this.codeActionSyncRequired = false;
+        return this.annotations;
+    }
+
+    public synchronized void setAnnotations(List<Annotation> annotations) {
+        this.annotations = annotations;
+    }
+
+    public synchronized void setAnonHolder(AnnotationHolder holder) {
+        this.anonHolder = holder;
+    }
+
+    public synchronized boolean isCodeActionSyncRequired() {
+        return this.codeActionSyncRequired;
+    }
+
+    /**
+     * Retrieves the commands needed to apply a CodeAction.
+     *
+     * @param offset The cursor position(offset) which should be evaluated for code action request.
+     * @return The list of commands, or null if none are given / the request times out
+     */
+    @SuppressWarnings("WeakerAccess")
+    public List<Either<Command, CodeAction>> codeAction(int offset) {
+        CodeActionParams params = new CodeActionParams();
+        params.setTextDocument(identifier);
+        Range range = new Range(DocumentUtils.offsetToLSPPos(editor, offset),
+                DocumentUtils.offsetToLSPPos(editor, offset));
+        params.setRange(range);
+
+        // Calculates the diagnostic context.
+        List<Diagnostic> diagnosticContext = new ArrayList<>();
+        diagnosticsFeature.withDiagnostics(diags -> diags.forEach(diagnostic -> {
+            int startOffset = DocumentUtils.lspPosToOffset(editor, diagnostic.getRange().getStart());
+            int endOffset = DocumentUtils.lspPosToOffset(editor, diagnostic.getRange().getEnd());
+            if (offset >= startOffset && offset <= endOffset) {
+                diagnosticContext.add(diagnostic);
+            }
+        }));
+
+        CodeActionContext context = new CodeActionContext(diagnosticContext);
+        params.setContext(context);
+        CompletableFuture<List<Either<Command, CodeAction>>> future = wrapper.getRequestManager().codeAction(params);
+        return wrapper.getRequestExecutor().waitFor(future, CODEACTION);
+    }
+
+    public CodeAction resolvedCodeAction(CodeAction codeAction) {
+        CompletableFuture<CodeAction> future = wrapper.getRequestManager().resolveCodeAction(codeAction);
+        return wrapper.getRequestExecutor().waitFor(future, CODEACTION);
+    }
+
+    /**
+     * Sends commands to execute to the server and applies the changes returned if the future returns a WorkspaceEdit.
+     *
+     * @param commands The commands to execute
+     */
+    public void executeCommands(List<Command> commands) {
+        wrapper.pool(() -> {
+            if (editor.isDisposed()) {
+                return;
+            }
+            commands.stream().map(c -> {
+                ExecuteCommandParams params = new ExecuteCommandParams();
+                params.setArguments(c.getArguments());
+                params.setCommand(c.getCommand());
+                return wrapper.getRequestManager().executeCommand(params);
+            }).filter(Objects::nonNull).forEach(f ->
+                    wrapper.getRequestExecutor().waitFor(f, EXECUTE_COMMAND));
+        });
+    }
+
+    public void requestAndShowCodeActions() {
+        wrapper.pool(() -> {
+            if (editor.isDisposed()) {
+                return;
+            }
+
+            // Sends the code action request and resolves incomplete code actions while off the EDT;
+            // only the annotation bookkeeping runs on the EDT.
+            int caretPos = computableReadAction(() -> editor.getCaretModel().getCurrentCaret().getOffset());
+            List<Either<Command, CodeAction>> codeActionResp = codeAction(caretPos);
+            if (codeActionResp == null || codeActionResp.isEmpty()) {
+                return;
+            }
+            List<Either<Command, CodeAction>> codeActions = new ArrayList<>();
+            for (Either<Command, CodeAction> element : codeActionResp) {
+                if (element == null) {
+                    continue;
+                }
+                if (element.isRight() && element.getRight().getEdit() == null) {
+                    CodeAction resolved = resolvedCodeAction(element.getRight());
+                    if (resolved != null && resolved.getEdit() != null) {
+                        codeActions.add(Either.forRight(resolved));
+                        continue;
+                    }
+                }
+                codeActions.add(element);
+            }
+            invokeLater(() -> showCodeActions(caretPos, codeActions));
+        });
+    }
+
+    private void showCodeActions(int caretPos, List<Either<Command, CodeAction>> codeActions) {
+        if (editor.isDisposed()) {
+            return;
+        }
+        if (annotations == null) {
+            annotations = new ArrayList<>();
+        }
+
+        codeActions.forEach(element -> {
+                if (element.isLeft()) {
+                    Command command = element.getLeft();
+                    Annotation annotWithCodeAction = null;
+                    for (Annotation annotation : annotations) {
+                        int start = annotation.getStartOffset();
+                        int end = annotation.getEndOffset();
+                        if (start <= caretPos && end >= caretPos) {
+                            if (annotation.getQuickFixes() == null || annotation.getQuickFixes().isEmpty()) {
+                                isTriggerIntentionActions = true;
+                            }
+                            annotation.registerFix(new LSPCommandFix(FileUtils.editorToURIString(editor), command),
+                                    new TextRange(start, end));
+                            codeActionSyncRequired = true;
+                            annotWithCodeAction = annotation;
+                            break;
+                        }
+                    }
+                    if (annotWithCodeAction != null) {
+                        annotations.remove(annotWithCodeAction);
+                        annotations.add(0, annotWithCodeAction);
+                    }
+                } else if (element.isRight()) {
+                    CodeAction codeAction = element.getRight();
+                    List<Diagnostic> diagnosticContext = codeAction.getDiagnostics();
+                    Annotation annotWithCodeAction = null;
+                    for (Annotation annotation : annotations) {
+                        int start = annotation.getStartOffset();
+                        int end = annotation.getEndOffset();
+                        if (start <= caretPos && end >= caretPos) {
+                            if (annotation.getQuickFixes() == null || annotation.getQuickFixes().isEmpty()) {
+                                isTriggerIntentionActions = true;
+                            }
+                            annotation.registerFix(new LSPCodeActionFix(FileUtils.editorToURIString(editor),
+                                    codeAction), new TextRange(start, end));
+                            codeActionSyncRequired = true;
+                            annotWithCodeAction = annotation;
+                            break;
+                        }
+                    }
+                    if (annotWithCodeAction != null) {
+                        annotations.remove(annotWithCodeAction);
+                        annotations.add(0, annotWithCodeAction);
+                    }
+
+                    // If the code actions does not have a diagnostics context, creates an intention action for
+                    // the current line.
+                    if ((diagnosticContext == null || diagnosticContext.isEmpty())
+                            && anonHolder != null && !codeActionSyncRequired) {
+                        // Calculates text range of the current line.
+                        int line = editor.getCaretModel().getCurrentCaret().getLogicalPosition().line;
+                        int startOffset = editor.getDocument().getLineStartOffset(line);
+                        int endOffset = editor.getDocument().getLineEndOffset(line);
+                        TextRange range = new TextRange(startOffset, endOffset);
+                        CodeAction finalCodeAction = codeAction;
+                        boolean found = silentAnnotations.stream()
+                                .anyMatch(silentAnnotation ->
+                                        silentAnnotation.getSecond().getStartOffset() == startOffset &&
+                                        silentAnnotation.getSecond().getEndOffset() == endOffset &&
+                                        silentAnnotation.getThird().getText().equals(finalCodeAction.getTitle())
+                                 );
+                        if (!found) {
+                            Tuple3<HighlightSeverity, TextRange, LSPCodeActionFix> sAnnotation =
+                                    new Tuple3<>(
+                                            HighlightSeverity.INFORMATION,
+                                            range,
+                                            new LSPCodeActionFix(FileUtils.editorToURIString(editor), codeAction)
+                                    );
+                            silentAnnotations.add(sAnnotation);
+                            isTriggerIntentionActions = true;
+                        }
+                        codeActionSyncRequired = true;
+                    }
+                }
+        });
+        // If code actions are updated, forcefully triggers the inspection tool.
+        if (codeActionSyncRequired) {
+            // double-delay the update to ensure that the code analyzer finishes.
+            invokeLater(diagnosticsFeature::restartDaemonCodeAnalyzer);
+        }
+    }
+
+    public List<Tuple3<HighlightSeverity, TextRange, LSPCodeActionFix>> getSilentAnnotations() {
+        return silentAnnotations;
+    }
+
+    public void triggerIntentionActions() {
+        if (isTriggerIntentionActions) {
+            isTriggerIntentionActions = false;
+            diagnosticsFeature.restartDaemonCodeAnalyzer();
+        }
+    }
+}

--- a/src/main/java/org/wso2/lsp4intellij/features/CodeActionFeature.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/CodeActionFeature.java
@@ -68,6 +68,7 @@ public final class CodeActionFeature {
     private final LanguageServerWrapper wrapper;
     private final TextDocumentIdentifier identifier;
     private final DiagnosticsFeature diagnosticsFeature;
+    private final CodeActionOverrides overrides;
 
     private List<Annotation> annotations = new ArrayList<>();
     private AnnotationHolder anonHolder;
@@ -76,11 +77,12 @@ public final class CodeActionFeature {
     private final List<Tuple3<HighlightSeverity, TextRange, LSPCodeActionFix>> silentAnnotations = new ArrayList<>();
 
     public CodeActionFeature(Editor editor, LanguageServerWrapper wrapper, TextDocumentIdentifier identifier,
-            DiagnosticsFeature diagnosticsFeature) {
+            DiagnosticsFeature diagnosticsFeature, CodeActionOverrides overrides) {
         this.editor = editor;
         this.wrapper = wrapper;
         this.identifier = identifier;
         this.diagnosticsFeature = diagnosticsFeature;
+        this.overrides = overrides;
     }
 
     /**
@@ -167,7 +169,7 @@ public final class CodeActionFeature {
             // Sends the code action request and resolves incomplete code actions while off the EDT;
             // only the annotation bookkeeping runs on the EDT.
             int caretPos = computableReadAction(() -> editor.getCaretModel().getCurrentCaret().getOffset());
-            List<Either<Command, CodeAction>> codeActionResp = codeAction(caretPos);
+            List<Either<Command, CodeAction>> codeActionResp = overrides.codeAction(caretPos);
             if (codeActionResp == null || codeActionResp.isEmpty()) {
                 return;
             }
@@ -177,7 +179,7 @@ public final class CodeActionFeature {
                     continue;
                 }
                 if (element.isRight() && element.getRight().getEdit() == null) {
-                    CodeAction resolved = resolvedCodeAction(element.getRight());
+                    CodeAction resolved = overrides.resolvedCodeAction(element.getRight());
                     if (resolved != null && resolved.getEdit() != null) {
                         codeActions.add(Either.forRight(resolved));
                         continue;

--- a/src/main/java/org/wso2/lsp4intellij/features/CodeActionFeature.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/CodeActionFeature.java
@@ -106,6 +106,16 @@ public final class CodeActionFeature {
     }
 
     /**
+     * Sets the sync-required flag {@link #getAnnotations()} clears. Package-private and used only by
+     * the test for that clearing: the production paths that raise this flag all live inside
+     * {@code showCodeActions}, which needs a real editor and a server response, so there is
+     * otherwise no way to observe the flag in anything other than its initial {@code false} state.
+     */
+    synchronized void markCodeActionSyncRequiredForTest() {
+        this.codeActionSyncRequired = true;
+    }
+
+    /**
      * Retrieves the commands needed to apply a CodeAction.
      *
      * @param offset The cursor position(offset) which should be evaluated for code action request.

--- a/src/main/java/org/wso2/lsp4intellij/features/CodeActionOverrides.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/CodeActionOverrides.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.features;
+
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import java.util.List;
+
+/**
+ * The subset of {@code EditorEventManager}'s public code-action methods that
+ * {@link CodeActionFeature} calls back into rather than calling on itself.
+ * <p>
+ * Both methods had no caller anywhere in this codebase other than
+ * {@link CodeActionFeature#requestAndShowCodeActions()} — being overridden by an extension's
+ * {@code EditorEventManager} subclass was their only purpose. As unqualified self-calls inside the
+ * old single class they dispatched virtually; inside {@code final CodeActionFeature} they cannot.
+ * See {@link CompletionOverrides} for the same reasoning in more detail.
+ */
+public interface CodeActionOverrides {
+
+    List<Either<Command, CodeAction>> codeAction(int offset);
+
+    CodeAction resolvedCodeAction(CodeAction codeAction);
+}

--- a/src/main/java/org/wso2/lsp4intellij/features/CompletionFeature.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/CompletionFeature.java
@@ -1,0 +1,384 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.features;
+
+import com.intellij.codeInsight.completion.InsertionContext;
+import com.intellij.codeInsight.lookup.AutoCompletionPolicy;
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import com.intellij.codeInsight.template.TemplateManager;
+import com.intellij.codeInsight.template.impl.TemplateImpl;
+import com.intellij.codeInsight.template.impl.TextExpression;
+import com.intellij.openapi.command.CommandProcessor;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.EditorModificationUtil;
+import com.intellij.openapi.project.Project;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.CompletionItem;
+import org.eclipse.lsp4j.CompletionItemKind;
+import org.eclipse.lsp4j.CompletionList;
+import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.InsertReplaceEdit;
+import org.eclipse.lsp4j.InsertTextFormat;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.jetbrains.annotations.NotNull;
+import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
+import org.wso2.lsp4intellij.contributors.icon.LSPIconProvider;
+import org.wso2.lsp4intellij.utils.DocumentUtils;
+import org.wso2.lsp4intellij.utils.GUIUtils;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import javax.swing.Icon;
+
+import static org.wso2.lsp4intellij.requests.Timeouts.COMPLETION;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeLater;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.writeAction;
+import static org.wso2.lsp4intellij.utils.DocumentUtils.toEither;
+
+/**
+ * Requests completion suggestions, converts them into lookup elements, and applies the
+ * insert-time text edits, commands, and snippet expansion a chosen item triggers.
+ *
+ * <p>Extracted from {@code EditorEventManager} as the second slice of the feature-layer
+ * decomposition (ARCHITECTURE.md section 2.4); {@code EditorEventManager} composes one instance
+ * per editor and delegates its completion-facing public methods to it with the same signatures
+ * and behavior they had before.
+ *
+ * <p>Three capabilities this feature needs are still owned by {@code EditorEventManager} — text
+ * edit application (the future {@code WorkspaceEditApplier}), LSP command execution (shared with
+ * code actions), and triggering signature help (a separate not-yet-extracted feature) — and are
+ * injected as narrow callbacks rather than duplicated here.
+ */
+public final class CompletionFeature {
+
+    public static final String SNIPPET_PLACEHOLDER_REGEX = "(\\$\\{\\d+:?(\\{)?[^{}]*(\\})?\\}|\\$\\d+)";
+
+    /**
+     * Matches {@code EditorEventManager.applyEdit(int, List, String, boolean, boolean)}, which
+     * this feature calls back into to apply insert-time text edits.
+     */
+    @FunctionalInterface
+    public interface EditApplier {
+        boolean apply(int version, List<Either<TextEdit, InsertReplaceEdit>> edits,
+                String name, boolean closeAfter, boolean setCaret);
+    }
+
+    private final Editor editor;
+    private final Project project;
+    private final LanguageServerWrapper wrapper;
+    private final TextDocumentIdentifier identifier;
+    private final List<String> completionTriggers;
+    private final EditApplier editApplier;
+    private final Consumer<List<Command>> commandExecutor;
+    private final Runnable signatureHelpTrigger;
+
+    public CompletionFeature(Editor editor, Project project, LanguageServerWrapper wrapper,
+            TextDocumentIdentifier identifier, List<String> completionTriggers, EditApplier editApplier,
+            Consumer<List<Command>> commandExecutor, Runnable signatureHelpTrigger) {
+        this.editor = editor;
+        this.project = project;
+        this.wrapper = wrapper;
+        this.identifier = identifier;
+        this.completionTriggers = completionTriggers;
+        this.editApplier = editApplier;
+        this.commandExecutor = commandExecutor;
+        this.signatureHelpTrigger = signatureHelpTrigger;
+    }
+
+    /**
+     * Returns the completion suggestions given a position.
+     *
+     * @param pos The LSP position
+     * @return The suggestions
+     */
+    public Iterable<? extends LookupElement> completion(Position pos) {
+
+        List<LookupElement> lookupItems = new ArrayList<>();
+        CompletableFuture<Either<List<CompletionItem>, CompletionList>> request = wrapper.getRequestManager()
+                .completion(new CompletionParams(identifier, pos));
+        Either<List<CompletionItem>, CompletionList> res =
+                wrapper.getRequestExecutor().waitFor(request, COMPLETION);
+        if (res == null) {
+            return lookupItems;
+        }
+        if (res.getLeft() != null) {
+            for (CompletionItem item : res.getLeft()) {
+                LookupElement lookupElement = createLookupItem(item);
+                if (lookupElement != null) {
+                    lookupItems.add(lookupElement);
+                }
+            }
+        } else if (res.getRight() != null) {
+            for (CompletionItem item : res.getRight().getItems()) {
+                LookupElement lookupElement = createLookupItem(item);
+                if (lookupElement != null) {
+                    lookupItems.add(lookupElement);
+                }
+            }
+        }
+        return lookupItems;
+    }
+
+    /**
+     * Creates a LookupElement given a CompletionItem.
+     *
+     * @param item The CompletionItem
+     * @return The corresponding LookupElement
+     */
+    @SuppressWarnings("WeakerAccess")
+    public LookupElement createLookupItem(CompletionItem item) {
+        Command command = item.getCommand();
+        String detail = item.getDetail();
+        String insertText = item.getInsertText();
+        CompletionItemKind kind = item.getKind();
+        String label = item.getLabel();
+        Either<TextEdit, InsertReplaceEdit> textEditEither = item.getTextEdit();
+        TextEdit textEdit = (textEditEither != null) ? textEditEither.getLeft() : null;
+        InsertReplaceEdit insertReplaceEdit = (textEditEither != null) ? textEditEither.getRight() : null;
+        List<TextEdit> addTextEdits = item.getAdditionalTextEdits();
+        String presentableText = StringUtils.isNotEmpty(label) ? label : (insertText != null) ? insertText : "";
+        String tailText = (detail != null) ? detail : "";
+        LSPIconProvider iconProvider = GUIUtils.getIconProviderFor(wrapper.getServerDefinition());
+        Icon icon = iconProvider.getCompletionIcon(kind);
+        LookupElementBuilder lookupElementBuilder;
+
+        String lookupString = null;
+        if (textEdit != null) {
+            lookupString = textEdit.getNewText();
+        } else if (insertReplaceEdit != null) {
+            lookupString = insertReplaceEdit.getNewText();
+        } else if (StringUtils.isNotEmpty(insertText)) {
+            lookupString = insertText;
+        } else if (StringUtils.isNotEmpty(label)) {
+            lookupString = label;
+        }
+        if (StringUtils.isEmpty(lookupString)) {
+            return null;
+        }
+        // Fixes IDEA internal assertion failure in windows.
+        lookupString = lookupString.replace(DocumentUtils.WIN_SEPARATOR, DocumentUtils.LINUX_SEPARATOR);
+
+        lookupElementBuilder = LookupElementBuilder.create(getLookupStringWithoutPlaceholders(item, lookupString));
+
+        lookupElementBuilder = addCompletionInsertHandlers(item, lookupElementBuilder, lookupString);
+
+        if (kind == CompletionItemKind.Keyword) {
+            lookupElementBuilder = lookupElementBuilder.withBoldness(true);
+        }
+
+        return lookupElementBuilder.withPresentableText(presentableText).withTypeText(tailText, true).withIcon(icon)
+                .withAutoCompletionPolicy(AutoCompletionPolicy.SETTINGS_DEPENDENT);
+    }
+
+    private String getLookupStringWithoutPlaceholders(CompletionItem item, String lookupString) {
+        if (item.getInsertTextFormat() == InsertTextFormat.Snippet) {
+            return convertPlaceHolders(lookupString);
+        } else {
+            return lookupString;
+        }
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public LookupElementBuilder addCompletionInsertHandlers(
+            CompletionItem item, LookupElementBuilder builder,
+            String lookupString) {
+
+        String label = item.getLabel();
+        Command command = item.getCommand();
+        List<TextEdit> addTextEdits = item.getAdditionalTextEdits();
+        InsertTextFormat format = item.getInsertTextFormat();
+
+        if (addTextEdits != null) {
+            builder = builder.withInsertHandler(
+                    (InsertionContext context, LookupElement lookupElement) -> invokeLater(() -> {
+                applyInitialTextEdit(item, context, lookupString);
+
+                if (format == InsertTextFormat.Snippet) {
+                    context.commitDocument();
+                    prepareAndRunSnippet(lookupString);
+                }
+
+                context.commitDocument();
+                editApplier.apply(Integer.MAX_VALUE, toEither(addTextEdits), "Completion : " + label, false, false);
+                if (command != null) {
+                    commandExecutor.accept(Collections.singletonList(command));
+                }
+            }));
+        } else if (command != null) {
+            builder = builder.withInsertHandler((InsertionContext context, LookupElement lookupElement) -> {
+                applyInitialTextEdit(item, context, lookupString);
+
+                if (format == InsertTextFormat.Snippet) {
+                    context.commitDocument();
+                    prepareAndRunSnippet(lookupString);
+                }
+                context.commitDocument();
+                commandExecutor.accept(Collections.singletonList(command));
+            });
+        } else {
+            builder = builder.withInsertHandler((InsertionContext context, LookupElement lookupElement) -> {
+                applyInitialTextEdit(item, context, lookupString);
+
+                if (format == InsertTextFormat.Snippet) {
+                    context.commitDocument();
+                    prepareAndRunSnippet(lookupString);
+                }
+            });
+        }
+        return builder;
+    }
+
+    private void applyInitialTextEdit(CompletionItem item, InsertionContext context, String lookupString) {
+        if (item.getTextEdit() != null) {
+            // remove intellij edit, server is controlling insertion
+            writeAction(() -> {
+                Runnable runnable = () -> this.editor.getDocument()
+                        .deleteString(context.getStartOffset(), context.getTailOffset());
+
+                CommandProcessor.getInstance()
+                        .executeCommand(project, runnable,
+                                "Removing Intellij Completion", "LSPPlugin",
+                                editor.getDocument());
+            });
+            context.commitDocument();
+
+            if (item.getTextEdit().isLeft()) {
+                item.getTextEdit().getLeft().setNewText(getLookupStringWithoutPlaceholders(item, lookupString));
+            }
+
+            editApplier.apply(Integer.MAX_VALUE, Collections.singletonList(item.getTextEdit()), "text edit",
+                    false, true);
+        } else {
+            // client handles insertion, determine a prefix (to allow completions of partially matching items)
+            int prefixLength = getCompletionPrefixLength(context.getStartOffset());
+
+            writeAction(() -> {
+                Runnable runnable = () -> this.editor.getDocument()
+                        .deleteString(context.getStartOffset() - prefixLength,
+                                context.getStartOffset());
+
+                CommandProcessor.getInstance()
+                        .executeCommand(project, runnable, "Removing Prefix", "LSPPlugin", editor.getDocument());
+            });
+            context.commitDocument();
+
+        }
+    }
+
+    private int getCompletionPrefixLength(int offset) {
+        return getCompletionPrefix(this.editor, offset).length();
+    }
+
+    @NotNull
+    public String getCompletionPrefix(Editor editor, int offset) {
+        String delimiterString = String.join("", this.completionTriggers) + " \t\n\r";
+        String documentText = editor.getDocument().getText();
+        int lastIndex = -1;
+        for (char delimiter : delimiterString.toCharArray()) {
+            int index = documentText.substring(0, offset).lastIndexOf(delimiter);
+            if (index > lastIndex) {
+                lastIndex = index;
+            }
+        }
+        return lastIndex >= 0 ? documentText.substring(lastIndex + 1, offset) : documentText.substring(0, offset);
+    }
+
+    @SuppressWarnings("WeakerAccess")
+    public void prepareAndRunSnippet(String insertText) {
+
+        List<SnippetVariable> variables = new ArrayList<>();
+        // Extracts variables using placeholder REGEX pattern.
+        Matcher varMatcher = Pattern.compile(SNIPPET_PLACEHOLDER_REGEX).matcher(insertText);
+        while (varMatcher.find()) {
+            variables.add(new SnippetVariable(varMatcher.group(), varMatcher.start(), varMatcher.end()));
+        }
+        if (variables.isEmpty()) {
+            return;
+        }
+        variables.sort(Comparator.comparingInt(o -> o.startIndex));
+        final String[] finalInsertText = {insertText};
+        variables.forEach(var -> finalInsertText[0] = finalInsertText[0].replace(var.lspSnippetText, "$"));
+
+        String[] splitInsertText = finalInsertText[0].split("\\$");
+        finalInsertText[0] = String.join("", splitInsertText);
+
+        TemplateImpl template = (TemplateImpl) TemplateManager
+                .getInstance(project).createTemplate(finalInsertText[0],
+                "lsp4intellij");
+        template.parseSegments();
+
+        // prevent "smart" indent of next line...
+        template.setToIndent(false);
+
+        final int[] varIndex = {0};
+        variables.forEach(var -> {
+            template.addTextSegment(splitInsertText[varIndex[0]]);
+            template.addVariable(varIndex[0] + "_" + var.variableValue, new TextExpression(var.variableValue),
+                    new TextExpression(var.variableValue), true, false);
+            varIndex[0]++;
+        });
+        // If the snippet text ends with a placeholder, there will be no string segment left to append after the last
+        // variable.
+        if (splitInsertText.length != variables.size()) {
+            template.addTextSegment(splitInsertText[splitInsertText.length - 1]);
+        }
+        template.setInline(true);
+        if (variables.size() > 0) {
+            EditorModificationUtil.moveCaretRelatively(editor, -template.getTemplateText().length());
+        }
+        TemplateManager.getInstance(project).startTemplate(editor, template);
+        signatureHelpTrigger.run();
+    }
+
+    private String convertPlaceHolders(String insertText) {
+        return insertText.replaceAll(SNIPPET_PLACEHOLDER_REGEX, "");
+    }
+
+    static class SnippetVariable {
+        String lspSnippetText;
+        int startIndex;
+        int endIndex;
+        String variableValue;
+        String intellijSnippetText;
+
+        SnippetVariable(String text, int start, int end) {
+            this.lspSnippetText = text;
+            this.startIndex = start;
+            this.endIndex = end;
+            this.variableValue = getVariableValue(text);
+        }
+
+        private String getVariableValue(String lspVarSnippet) {
+            if (lspVarSnippet.contains(":")) {
+                lspVarSnippet = lspVarSnippet.replace("\\", "");
+                return lspVarSnippet.substring(lspVarSnippet.indexOf(':') + 1, lspVarSnippet.lastIndexOf('}'));
+            }
+            return " ";
+        }
+    }
+}

--- a/src/main/java/org/wso2/lsp4intellij/features/CompletionFeature.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/CompletionFeature.java
@@ -70,23 +70,13 @@ import static org.wso2.lsp4intellij.utils.DocumentUtils.toEither;
  * and behavior they had before.
  *
  * <p>Three capabilities this feature needs are still owned by {@code EditorEventManager} — text
- * edit application (the future {@code WorkspaceEditApplier}), LSP command execution (shared with
- * code actions), and triggering signature help (a separate not-yet-extracted feature) — and are
- * injected as narrow callbacks rather than duplicated here.
+ * edit application (the future {@code WorkspaceEditApplier}; see {@link EditApplier}), LSP command
+ * execution (shared with code actions), and triggering signature help (a separate feature) — and
+ * are injected as narrow callbacks rather than duplicated here.
  */
 public final class CompletionFeature {
 
     public static final String SNIPPET_PLACEHOLDER_REGEX = "(\\$\\{\\d+:?(\\{)?[^{}]*(\\})?\\}|\\$\\d+)";
-
-    /**
-     * Matches {@code EditorEventManager.applyEdit(int, List, String, boolean, boolean)}, which
-     * this feature calls back into to apply insert-time text edits.
-     */
-    @FunctionalInterface
-    public interface EditApplier {
-        boolean apply(int version, List<Either<TextEdit, InsertReplaceEdit>> edits,
-                String name, boolean closeAfter, boolean setCaret);
-    }
 
     private final Editor editor;
     private final Project project;

--- a/src/main/java/org/wso2/lsp4intellij/features/CompletionFeature.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/CompletionFeature.java
@@ -86,10 +86,12 @@ public final class CompletionFeature {
     private final EditApplier editApplier;
     private final Consumer<List<Command>> commandExecutor;
     private final Runnable signatureHelpTrigger;
+    private final CompletionOverrides overrides;
 
     public CompletionFeature(Editor editor, Project project, LanguageServerWrapper wrapper,
             TextDocumentIdentifier identifier, List<String> completionTriggers, EditApplier editApplier,
-            Consumer<List<Command>> commandExecutor, Runnable signatureHelpTrigger) {
+            Consumer<List<Command>> commandExecutor, Runnable signatureHelpTrigger,
+            CompletionOverrides overrides) {
         this.editor = editor;
         this.project = project;
         this.wrapper = wrapper;
@@ -98,6 +100,7 @@ public final class CompletionFeature {
         this.editApplier = editApplier;
         this.commandExecutor = commandExecutor;
         this.signatureHelpTrigger = signatureHelpTrigger;
+        this.overrides = overrides;
     }
 
     /**
@@ -118,14 +121,14 @@ public final class CompletionFeature {
         }
         if (res.getLeft() != null) {
             for (CompletionItem item : res.getLeft()) {
-                LookupElement lookupElement = createLookupItem(item);
+                LookupElement lookupElement = overrides.createLookupItem(item);
                 if (lookupElement != null) {
                     lookupItems.add(lookupElement);
                 }
             }
         } else if (res.getRight() != null) {
             for (CompletionItem item : res.getRight().getItems()) {
-                LookupElement lookupElement = createLookupItem(item);
+                LookupElement lookupElement = overrides.createLookupItem(item);
                 if (lookupElement != null) {
                     lookupItems.add(lookupElement);
                 }
@@ -175,7 +178,7 @@ public final class CompletionFeature {
 
         lookupElementBuilder = LookupElementBuilder.create(getLookupStringWithoutPlaceholders(item, lookupString));
 
-        lookupElementBuilder = addCompletionInsertHandlers(item, lookupElementBuilder, lookupString);
+        lookupElementBuilder = overrides.addCompletionInsertHandlers(item, lookupElementBuilder, lookupString);
 
         if (kind == CompletionItemKind.Keyword) {
             lookupElementBuilder = lookupElementBuilder.withBoldness(true);
@@ -210,7 +213,7 @@ public final class CompletionFeature {
 
                 if (format == InsertTextFormat.Snippet) {
                     context.commitDocument();
-                    prepareAndRunSnippet(lookupString);
+                    overrides.prepareAndRunSnippet(lookupString);
                 }
 
                 context.commitDocument();
@@ -225,7 +228,7 @@ public final class CompletionFeature {
 
                 if (format == InsertTextFormat.Snippet) {
                     context.commitDocument();
-                    prepareAndRunSnippet(lookupString);
+                    overrides.prepareAndRunSnippet(lookupString);
                 }
                 context.commitDocument();
                 commandExecutor.accept(Collections.singletonList(command));
@@ -236,7 +239,7 @@ public final class CompletionFeature {
 
                 if (format == InsertTextFormat.Snippet) {
                     context.commitDocument();
-                    prepareAndRunSnippet(lookupString);
+                    overrides.prepareAndRunSnippet(lookupString);
                 }
             });
         }

--- a/src/main/java/org/wso2/lsp4intellij/features/CompletionOverrides.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/CompletionOverrides.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.features;
+
+import com.intellij.codeInsight.lookup.LookupElement;
+import com.intellij.codeInsight.lookup.LookupElementBuilder;
+import org.eclipse.lsp4j.CompletionItem;
+
+/**
+ * The subset of {@code EditorEventManager}'s public completion methods that {@link CompletionFeature}
+ * calls back into rather than calling on itself.
+ * <p>
+ * Before the feature-layer decomposition these were unqualified self-calls inside a single
+ * {@code EditorEventManager}, so they dispatched virtually: an extension supplying a subclass via
+ * {@code LSPExtensionManager.getExtendedEditorEventManagerFor} could override any of them and have
+ * the override take effect on the internal completion path. {@link CompletionFeature} is
+ * {@code final}, so a plain self-call inside it can never reach such an override. Routing these
+ * three calls through the composing {@code EditorEventManager} — which implements this interface
+ * with the same method signatures it already exposed — restores that dispatch.
+ * <p>
+ * This is deliberately an interface rather than a reference to {@code EditorEventManager}: the
+ * feature depends only on the operations it needs to re-dispatch, not on the class composing it.
+ */
+public interface CompletionOverrides {
+
+    LookupElement createLookupItem(CompletionItem item);
+
+    LookupElementBuilder addCompletionInsertHandlers(CompletionItem item, LookupElementBuilder builder,
+            String lookupString);
+
+    void prepareAndRunSnippet(String insertText);
+}

--- a/src/main/java/org/wso2/lsp4intellij/features/DiagnosticsFeature.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/DiagnosticsFeature.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.features;
+
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.project.Project;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiFile;
+import org.eclipse.lsp4j.Diagnostic;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.Consumer;
+
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableReadAction;
+
+/**
+ * Owns one editor's most recently published diagnostics and the "annotator needs to re-render"
+ * flag, and the DaemonCodeAnalyzer restart that publishing (or an attached code-action fix) forces.
+ *
+ * <p>Extracted from {@code EditorEventManager} as the first slice of the feature-layer decomposition
+ * (ARCHITECTURE.md section 2.4); {@code EditorEventManager} composes one instance per editor and
+ * delegates its diagnostics-facing methods to it with the same signatures and behavior it had before.
+ * The class is otherwise self-contained: no static lookups, no dependency on the wrapper or on
+ * {@code EditorEventManager} itself.
+ */
+public final class DiagnosticsFeature {
+
+    private static final Logger LOG = Logger.getInstance(DiagnosticsFeature.class);
+
+    private final Editor editor;
+    private final Project project;
+    private final List<Diagnostic> diagnostics = new ArrayList<>();
+    private volatile boolean syncRequired = true;
+
+    public DiagnosticsFeature(Editor editor, Project project) {
+        this.editor = editor;
+        this.project = project;
+    }
+
+    /**
+     * Replaces the diagnostics for this editor and, unless both the old and new lists are empty,
+     * marks a re-sync required and forces a full DaemonCodeAnalyzer pass so the annotator picks up
+     * the change.
+     */
+    public void publish(List<Diagnostic> diagnostics) {
+        if (editor.isDisposed() || (this.diagnostics.isEmpty() && diagnostics.isEmpty())) {
+            return;
+        }
+        synchronized (this.diagnostics) {
+            this.diagnostics.clear();
+            this.diagnostics.addAll(diagnostics);
+            syncRequired = true;
+            restartDaemonCodeAnalyzer();
+        }
+    }
+
+    /**
+     * Returns the current diagnostics and clears the sync-required flag. Returns the same mutable
+     * list instance {@link #publish} mutates, not a defensive copy — matching the original
+     * {@code EditorEventManager.getDiagnostics()} contract, which callers such as {@code LSPAnnotator}
+     * already tolerate a concurrent-modification exception from.
+     */
+    public synchronized List<Diagnostic> diagnostics() {
+        syncRequired = false;
+        return diagnostics;
+    }
+
+    public synchronized boolean isSyncRequired() {
+        return syncRequired;
+    }
+
+    /**
+     * Runs {@code action} with exclusive access to the live diagnostics list, e.g. to filter it by
+     * range for a code-action request without a concurrent {@link #publish} interleaving. Locks on
+     * the same monitor {@link #publish} does, matching the {@code synchronized (this.diagnostics)}
+     * block this was extracted from.
+     */
+    public void withDiagnostics(Consumer<List<Diagnostic>> action) {
+        synchronized (diagnostics) {
+            action.accept(diagnostics);
+        }
+    }
+
+    /**
+     * Forces a full DaemonCodeAnalyzer pass for this editor's file, so the annotator re-runs and
+     * picks up whatever changed. Public because {@code EditorEventManager}'s code-action handling
+     * — not yet extracted into its own feature — also calls this after attaching a fix to an
+     * existing annotation.
+     */
+    public void restartDaemonCodeAnalyzer() {
+        computableReadAction(() -> {
+            final PsiFile file = PsiDocumentManager.getInstance(project).getCachedPsiFile(editor.getDocument());
+            if (file == null) {
+                return null;
+            }
+            LOG.debug("Triggering force full DaemonCodeAnalyzer execution.");
+            DaemonCodeAnalyzer.getInstance(project).restart(file);
+            return null;
+        });
+    }
+}

--- a/src/main/java/org/wso2/lsp4intellij/features/EditApplier.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/EditApplier.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.features;
+
+import org.eclipse.lsp4j.InsertReplaceEdit;
+import org.eclipse.lsp4j.TextEdit;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+
+import java.util.List;
+
+/**
+ * Matches {@code EditorEventManager.applyEdit(int, List, String, boolean, boolean)} — the future
+ * {@code WorkspaceEditApplier} (ARCHITECTURE.md section 2.4) that hasn't been extracted yet.
+ * Feature classes that need to write text edits but don't own that logic themselves (currently
+ * {@link CompletionFeature} and {@link FormattingFeature}) take it as this injected callback
+ * instead, matching the narrow-callback pattern used elsewhere in this decomposition until an
+ * {@code EditorContext}-style shared session object exists to hold it.
+ */
+@FunctionalInterface
+public interface EditApplier {
+    boolean apply(int version, List<Either<TextEdit, InsertReplaceEdit>> edits,
+            String name, boolean closeAfter, boolean setCaret);
+}

--- a/src/main/java/org/wso2/lsp4intellij/features/FormattingFeature.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/FormattingFeature.java
@@ -1,0 +1,133 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.features;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.SelectionModel;
+import org.eclipse.lsp4j.DocumentFormattingParams;
+import org.eclipse.lsp4j.DocumentRangeFormattingParams;
+import org.eclipse.lsp4j.FormattingOptions;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.TextEdit;
+import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
+import org.wso2.lsp4intellij.utils.DocumentUtils;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableReadAction;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeLater;
+import static org.wso2.lsp4intellij.utils.DocumentUtils.toEither;
+
+/**
+ * Requests formatting for the whole document or the current selection, and applies the resulting
+ * text edits.
+ *
+ * <p>Extracted from {@code EditorEventManager} as part of the feature-layer decomposition
+ * (ARCHITECTURE.md section 2.4); {@code EditorEventManager} composes one instance per editor and
+ * keeps {@code reformat()}/{@code reformatSelection()} as public delegating facades with unchanged
+ * signatures, since {@code ReformatHandler} and {@code LSPShowReformatDialogAction} call them
+ * directly.
+ *
+ * <p>Text edit application is still owned by {@code EditorEventManager} (the future
+ * {@code WorkspaceEditApplier}), so it's injected here as an {@link EditApplier} callback — the
+ * same one {@link CompletionFeature} uses.
+ */
+public final class FormattingFeature {
+
+    private final Editor editor;
+    private final LanguageServerWrapper wrapper;
+    private final TextDocumentIdentifier identifier;
+    private final EditApplier editApplier;
+
+    public FormattingFeature(Editor editor, LanguageServerWrapper wrapper, TextDocumentIdentifier identifier,
+            EditApplier editApplier) {
+        this.editor = editor;
+        this.wrapper = wrapper;
+        this.identifier = identifier;
+        this.editApplier = editApplier;
+    }
+
+    /**
+     * Reformat the whole document.
+     */
+    public void reformat() {
+        wrapper.pool(() -> {
+            if (editor.isDisposed()) {
+                return;
+            }
+            DocumentFormattingParams params = new DocumentFormattingParams();
+            params.setTextDocument(identifier);
+            FormattingOptions options = new FormattingOptions();
+            options.setTabSize(DocumentUtils.getTabSize(editor));
+            options.setInsertSpaces(DocumentUtils.shouldUseSpaces(editor));
+            params.setOptions(options);
+
+            CompletableFuture<List<? extends TextEdit>> request = wrapper.getRequestManager().formatting(params);
+            if (request == null) {
+                return;
+            }
+            request.thenAccept(formatting -> {
+                if (formatting != null) {
+                    invokeLater(() -> editApplier.apply(Integer.MAX_VALUE, toEither((List<TextEdit>) formatting),
+                            "Reformat document", false, false));
+                }
+            });
+        });
+    }
+
+    /**
+     * Reformat the text currently selected in the editor.
+     */
+    public void reformatSelection() {
+        wrapper.pool(() -> {
+            if (editor.isDisposed()) {
+                return;
+            }
+            DocumentRangeFormattingParams params = new DocumentRangeFormattingParams();
+            params.setTextDocument(identifier);
+            SelectionModel selectionModel = editor.getSelectionModel();
+            int start = computableReadAction(selectionModel::getSelectionStart);
+            int end = computableReadAction(selectionModel::getSelectionEnd);
+            Position startingPos = DocumentUtils.offsetToLSPPos(editor, start);
+            Position endPos = DocumentUtils.offsetToLSPPos(editor, end);
+            params.setRange(new Range(startingPos, endPos));
+            // Todo - Make Formatting Options configurable
+            FormattingOptions options = new FormattingOptions();
+            options.setTabSize(DocumentUtils.getTabSize(editor));
+            options.setInsertSpaces(DocumentUtils.shouldUseSpaces(editor));
+            params.setOptions(options);
+
+            CompletableFuture<List<? extends TextEdit>> request = wrapper.getRequestManager().rangeFormatting(params);
+            if (request == null) {
+                return;
+            }
+            request.thenAccept(formatting -> {
+                if (formatting == null) {
+                    return;
+                }
+                invokeLater(() -> {
+                    if (!editor.isDisposed()) {
+                        editApplier.apply(Integer.MAX_VALUE, toEither((List<TextEdit>) formatting),
+                                "Reformat selection", false, false);
+                    }
+                });
+            });
+        });
+    }
+}

--- a/src/main/java/org/wso2/lsp4intellij/features/HoverFeature.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/HoverFeature.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.features;
+
+import com.intellij.codeInsight.hint.HintManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.LogicalPosition;
+import com.intellij.ui.Hint;
+import org.apache.commons.lang3.StringUtils;
+import org.eclipse.lsp4j.Hover;
+import org.eclipse.lsp4j.HoverParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
+import org.wso2.lsp4intellij.requests.HoverHandler;
+import org.wso2.lsp4intellij.utils.DocumentUtils;
+
+import java.awt.Point;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+import static org.wso2.lsp4intellij.editor.EditorEventManagerBase.getIsCtrlDown;
+import static org.wso2.lsp4intellij.requests.Timeouts.HOVER;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableReadAction;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeLater;
+import static org.wso2.lsp4intellij.utils.GUIUtils.createAndShowEditorHint;
+
+/**
+ * Requests hover documentation for a position and shows it as an editor hint.
+ *
+ * <p>Extracted from {@code EditorEventManager} as part of the feature-layer decomposition
+ * (ARCHITECTURE.md section 2.4). {@code EditorEventManager} composes one instance per editor and
+ * calls {@link #showHoverAt} from both {@code quickDoc} (the explicit "show documentation" action)
+ * and {@code mouseMoved} (hover-on-dwell); those two callers keep their own bookkeeping
+ * ({@code predTime}, ctrl-range navigation state) since that's mouse/navigation glue, not hover
+ * logic itself.
+ *
+ * <p>The currently shown hint is still tracked by {@code EditorEventManager} (read by
+ * {@code mouseMoved} to hide a stale one), so it's injected here as a setter callback rather than
+ * owned by this feature — a narrower stand-in for the {@code EditorContext} shared session object
+ * section 2.4 describes, which doesn't exist yet.
+ */
+public final class HoverFeature {
+
+    private static final Logger LOG = Logger.getInstance(HoverFeature.class);
+
+    private final Editor editor;
+    private final LanguageServerWrapper wrapper;
+    private final TextDocumentIdentifier identifier;
+    private final Consumer<Hint> hintSetter;
+
+    public HoverFeature(Editor editor, LanguageServerWrapper wrapper, TextDocumentIdentifier identifier,
+            Consumer<Hint> hintSetter) {
+        this.editor = editor;
+        this.wrapper = wrapper;
+        this.identifier = identifier;
+        this.hintSetter = hintSetter;
+    }
+
+    /**
+     * Requests hover documentation at the given editor position and, if any is returned, shows it
+     * as a hint at the given point.
+     *
+     * @param editorPos The editor position
+     * @param point     The point at which to show the hint
+     */
+    public void showHoverAt(LogicalPosition editorPos, Point point) {
+        Position serverPos = computableReadAction(() -> DocumentUtils.logicalToLSPPos(editorPos, editor));
+        CompletableFuture<Hover> request = wrapper.getRequestManager().hover(new HoverParams(identifier, serverPos));
+        if (request == null) {
+            return;
+        }
+        Hover hover = wrapper.getRequestExecutor().waitFor(request, HOVER);
+        if (hover == null) {
+            LOG.debug(String.format("Hover is null for file %s and pos (%d;%d)", identifier.getUri(),
+                    serverPos.getLine(), serverPos.getCharacter()));
+            return;
+        }
+
+        String string = HoverHandler.getHoverString(hover);
+        if (StringUtils.isEmpty(string)) {
+            LOG.warn(String.format("Hover string returned is empty for file %s and pos (%d;%d)",
+                    identifier.getUri(), serverPos.getLine(), serverPos.getCharacter()));
+            return;
+        }
+
+        if (getIsCtrlDown()) {
+            invokeLater(() -> {
+                if (!editor.isDisposed()) {
+                    hintSetter.accept(createAndShowEditorHint(editor, string, point, HintManager.HIDE_BY_OTHER_HINT));
+                }
+            });
+        } else {
+            invokeLater(() -> {
+                if (!editor.isDisposed()) {
+                    hintSetter.accept(createAndShowEditorHint(editor, string, point));
+                }
+            });
+        }
+    }
+}

--- a/src/main/java/org/wso2/lsp4intellij/features/NavigationFeature.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/NavigationFeature.java
@@ -133,7 +133,10 @@ public final class NavigationFeature {
         CompletableFuture<List<? extends Location>> request = wrapper.getRequestManager().references(params);
         List<? extends Location> res = wrapper.getRequestExecutor().waitFor(request, REFERENCES);
         if (res == null || res.isEmpty()) {
-            return new Pair<>(null, null);
+            // Empty, not null: LSPInplaceRenamer.collectRefs() streams the first list and passes the
+            // second to LSPRenameProcessor.addEditors(), which calls List.addAll(...) on it — both
+            // would NPE on a null list where callers that do check for null are unaffected.
+            return new Pair<>(new ArrayList<>(), new ArrayList<>());
         }
         List<VirtualFile> openedEditors = new ArrayList<>();
         List<PsiElement> elements = new ArrayList<>();

--- a/src/main/java/org/wso2/lsp4intellij/features/NavigationFeature.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/NavigationFeature.java
@@ -1,0 +1,221 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.features;
+
+import com.intellij.openapi.application.ApplicationManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.LogicalPosition;
+import com.intellij.openapi.editor.ScrollType;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.fileEditor.OpenFileDescriptor;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.util.TextRange;
+import com.intellij.openapi.vfs.VfsUtil;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiDocumentManager;
+import com.intellij.psi.PsiElement;
+import org.eclipse.lsp4j.DefinitionParams;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.LocationLink;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.ReferenceContext;
+import org.eclipse.lsp4j.ReferenceParams;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
+import org.wso2.lsp4intellij.contributors.psi.LSPPsiElement;
+import org.wso2.lsp4intellij.utils.DocumentUtils;
+import org.wso2.lsp4intellij.utils.FileUtils;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.wso2.lsp4intellij.requests.Timeouts.DEFINITION;
+import static org.wso2.lsp4intellij.requests.Timeouts.REFERENCES;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableReadAction;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.computableWriteAction;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeAndWait;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.writeAction;
+
+/**
+ * Resolves go-to-definition and find-references requests, and opens/navigates to their locations.
+ *
+ * <p>Extracted from {@code EditorEventManager} as part of the feature-layer decomposition
+ * (ARCHITECTURE.md section 2.4); {@code EditorEventManager} composes one instance per editor and
+ * keeps {@code references()}/{@code gotoLocation()} as public delegating facades with unchanged
+ * signatures, since {@code LSPReferencesAction}, {@code LSPRenameHandler},
+ * {@code LSPRenameProcessor}, and {@code LSPInplaceRenamer} call {@code references()} directly on
+ * an {@code EditorEventManager} instance.
+ *
+ * <p>Unlike the other extractions so far, this one needed no injected callbacks:
+ * {@code EditorEventManager} keeps ctrl+click/ctrl-hover's navigation-preview highlight
+ * ({@code createCtrlRange}, {@code trySourceNavigationAndHover}) to itself, since that logic reads
+ * and writes the ctrl-range global slot on {@code EditorEventManagerBase} (mouse/UI glue, not
+ * navigation logic), and calls into {@link #definition} and {@link #gotoLocation} for the actual
+ * requests.
+ */
+public final class NavigationFeature {
+
+    private static final Logger LOG = Logger.getInstance(NavigationFeature.class);
+
+    private final Editor editor;
+    private final Project project;
+    private final LanguageServerWrapper wrapper;
+    private final TextDocumentIdentifier identifier;
+
+    public NavigationFeature(Editor editor, Project project, LanguageServerWrapper wrapper,
+            TextDocumentIdentifier identifier) {
+        this.editor = editor;
+        this.project = project;
+        this.wrapper = wrapper;
+        this.identifier = identifier;
+    }
+
+    /**
+     * Returns the position of the definition given a position in the editor.
+     *
+     * @param position The position
+     * @return The location of the definition
+     */
+    public Location definition(Position position) {
+        DefinitionParams params = new DefinitionParams(identifier, position);
+        CompletableFuture<Either<List<? extends Location>, List<? extends LocationLink>>> request =
+                wrapper.getRequestManager().definition(params);
+
+        Either<List<? extends Location>, List<? extends LocationLink>> definition =
+                wrapper.getRequestExecutor().waitFor(request, DEFINITION);
+        if (definition == null) {
+            return null;
+        }
+        if (definition.isLeft() && !definition.getLeft().isEmpty()) {
+            return definition.getLeft().get(0);
+        } else if (definition.isRight() && !definition.getRight().isEmpty()) {
+            var def = definition.getRight().get(0);
+            return new Location(def.getTargetUri(), def.getTargetRange());
+        }
+        return null;
+    }
+
+    /**
+     * Returns the references given the position of the word to search for.
+     * May be called from any thread; opening and closing editors for reference locations is marshaled
+     * to the event dispatch thread. When called from a background thread, the read lock must not be held.
+     *
+     * @param offset The offset in the editor
+     * @return An array of PsiElement
+     */
+    public Pair<List<PsiElement>, List<VirtualFile>> references(int offset, boolean getOriginalElement,
+            boolean close) {
+        Position lspPos = DocumentUtils.offsetToLSPPos(editor, offset);
+        TextDocumentIdentifier textDocumentIdentifier = new TextDocumentIdentifier(FileUtils.editorToURIString(editor));
+        ReferenceParams params = new ReferenceParams(
+                textDocumentIdentifier, lspPos, new ReferenceContext(getOriginalElement));
+        params.setPosition(lspPos);
+        params.setTextDocument(identifier);
+        CompletableFuture<List<? extends Location>> request = wrapper.getRequestManager().references(params);
+        List<? extends Location> res = wrapper.getRequestExecutor().waitFor(request, REFERENCES);
+        if (res == null || res.isEmpty()) {
+            return new Pair<>(null, null);
+        }
+        List<VirtualFile> openedEditors = new ArrayList<>();
+        List<PsiElement> elements = new ArrayList<>();
+        res.forEach(l -> {
+            Position start = l.getRange().getStart();
+            Position end = l.getRange().getEnd();
+            String uri = FileUtils.sanitizeURI(l.getUri());
+            VirtualFile file = FileUtils.virtualFileFromURI(uri);
+            Editor curEditor = FileUtils.editorFromUri(uri, project);
+            if (curEditor == null && file != null) {
+                OpenFileDescriptor descriptor = new OpenFileDescriptor(
+                        project, file, start.getLine(), start.getCharacter());
+                curEditor = openEditor(descriptor);
+                if (curEditor != null) {
+                    openedEditors.add(file);
+                }
+            }
+            if (curEditor == null) {
+                LOG.warn("Error occurred in LSP references.");
+                return;
+            }
+            Editor refEditor = curEditor;
+            elements.add(computableReadAction(() -> {
+                int logicalStart = DocumentUtils.lspPosToOffset(refEditor, start);
+                int logicalEnd = DocumentUtils.lspPosToOffset(refEditor, end);
+                String name = refEditor.getDocument().getText(new TextRange(logicalStart, logicalEnd));
+                return new LSPPsiElement(name, project, logicalStart, logicalEnd,
+                        PsiDocumentManager.getInstance(project).getPsiFile(refEditor.getDocument()));
+            }));
+        });
+        if (close && !openedEditors.isEmpty()) {
+            invokeAndWait(() -> writeAction(
+                    () -> openedEditors.forEach(f -> FileEditorManager.getInstance(project).closeFile(f))));
+            openedEditors.clear();
+        }
+        return new Pair<>(elements, openedEditors);
+    }
+
+    /**
+     * Opens an editor for the given descriptor. Runs directly when called on the event dispatch thread;
+     * otherwise the opening is marshaled to the event dispatch thread and this method blocks until done.
+     */
+    private Editor openEditor(OpenFileDescriptor descriptor) {
+        if (ApplicationManager.getApplication().isDispatchThread()) {
+            return computableWriteAction(
+                    () -> FileEditorManager.getInstance(project).openTextEditor(descriptor, false));
+        }
+        if (ApplicationManager.getApplication().isReadAccessAllowed()) {
+            // Blocking on the event dispatch thread while holding the read lock would deadlock.
+            LOG.warn("Cannot open an editor for " + descriptor.getFile() + " from inside a read action");
+            return null;
+        }
+        Editor[] result = new Editor[1];
+        invokeAndWait(() -> result[0] = computableWriteAction(
+                () -> FileEditorManager.getInstance(project).openTextEditor(descriptor, false)));
+        return result[0];
+    }
+
+    public void gotoLocation(Location loc) {
+        VirtualFile file = null;
+        try {
+            file = VfsUtil.findFileByURL(new URL(loc.getUri()));
+        } catch (MalformedURLException e1) {
+            LOG.warn("Syntax Exception occurred for uri: " + loc.getUri());
+        }
+        if (file != null) {
+            OpenFileDescriptor descriptor = new OpenFileDescriptor(project, file);
+            VirtualFile finalFile = file;
+            writeAction(() -> {
+                FileEditorManager.getInstance(project).openTextEditor(descriptor, true);
+                Editor srcEditor = FileUtils.editorFromVirtualFile(finalFile, project);
+                if (srcEditor != null) {
+                    Position start = loc.getRange().getStart();
+                    LogicalPosition logicalPos = DocumentUtils.getTabsAwarePosition(srcEditor, start);
+                    if (logicalPos != null) {
+                        srcEditor.getCaretModel().moveToLogicalPosition(logicalPos);
+                        srcEditor.getScrollingModel().scrollTo(logicalPos, ScrollType.CENTER);
+                    }
+                }
+            });
+        } else {
+            LOG.warn("Empty file for " + loc.getUri());
+        }
+    }
+}

--- a/src/main/java/org/wso2/lsp4intellij/features/ReferenceLookup.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/ReferenceLookup.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.features;
+
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+
+import java.util.List;
+
+/**
+ * Reference lookup as {@link RenameFeature} needs it, to decide which files it opened only to
+ * compute the rename and should therefore close again afterwards.
+ * <p>
+ * {@code EditorEventManager.references(int, boolean, boolean)} is public and was called
+ * unqualified — so virtually — from {@code rename} before the feature-layer decomposition. Calling
+ * {@code NavigationFeature.references} directly would skip an extension's override of it. See
+ * {@link CompletionOverrides} for the same reasoning in more detail.
+ */
+@FunctionalInterface
+public interface ReferenceLookup {
+
+    Pair<List<PsiElement>, List<VirtualFile>> references(int offset, boolean getOriginalElement, boolean close);
+}

--- a/src/main/java/org/wso2/lsp4intellij/features/RenameFeature.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/RenameFeature.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.features;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.fileEditor.FileEditorManager;
+import com.intellij.openapi.project.Project;
+import com.intellij.openapi.util.Pair;
+import com.intellij.openapi.vfs.VirtualFile;
+import com.intellij.psi.PsiElement;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.RenameParams;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.WorkspaceEdit;
+import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
+import org.wso2.lsp4intellij.contributors.rename.LSPRenameProcessor;
+import org.wso2.lsp4intellij.requests.WorkspaceEditHandler;
+import org.wso2.lsp4intellij.utils.DocumentUtils;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeLater;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.writeAction;
+
+/**
+ * Renames a symbol: finds its references first (so files opened only to compute the workspace
+ * edit can be closed again afterward), then sends the LSP rename request and applies the result.
+ *
+ * <p>Extracted from {@code EditorEventManager} as part of the feature-layer decomposition
+ * (ARCHITECTURE.md section 2.4); {@code EditorEventManager} composes one instance per editor and
+ * keeps {@code rename(String)} as a public delegating facade with an unchanged signature, since
+ * {@code LSPRenameHandler} calls it directly.
+ *
+ * <p>Depends directly on this editor's {@link NavigationFeature} for the reference lookup — the
+ * same peer-feature composition {@link CodeActionFeature} uses for {@link DiagnosticsFeature},
+ * not a stand-in for the not-yet-built {@code EditorContext}.
+ */
+public final class RenameFeature {
+
+    private final Editor editor;
+    private final Project project;
+    private final LanguageServerWrapper wrapper;
+    private final TextDocumentIdentifier identifier;
+    private final NavigationFeature navigationFeature;
+
+    public RenameFeature(Editor editor, Project project, LanguageServerWrapper wrapper,
+            TextDocumentIdentifier identifier, NavigationFeature navigationFeature) {
+        this.editor = editor;
+        this.project = project;
+        this.wrapper = wrapper;
+        this.identifier = identifier;
+        this.navigationFeature = navigationFeature;
+    }
+
+    public void rename(String renameTo) {
+        rename(renameTo, editor.getCaretModel().getCurrentCaret().getOffset());
+    }
+
+    /**
+     * Rename a symbol in the document.
+     *
+     * @param renameTo The new name
+     */
+    public void rename(String renameTo, int offset) {
+        wrapper.pool(() -> {
+            if (editor.isDisposed()) {
+                return;
+            }
+            VirtualFile[] openedFiles = FileEditorManager.getInstance(project).getOpenFiles();
+            Pair<List<PsiElement>, List<VirtualFile>> references = navigationFeature.references(offset, true, false);
+            List<VirtualFile> toClose = new ArrayList<>();
+            if (references.getSecond() != null) {
+                for (VirtualFile file : references.getSecond()) {
+                    if (!Arrays.asList(openedFiles).contains(file)) {
+                        toClose.add(file);
+                    }
+                }
+            }
+            Position servPos = DocumentUtils.offsetToLSPPos(editor, offset);
+            RenameParams params = new RenameParams(identifier, servPos, renameTo);
+            CompletableFuture<WorkspaceEdit> request = wrapper.getRequestManager().rename(params);
+            if (request != null) {
+                request.thenAccept(res -> {
+                    boolean isApplied = WorkspaceEditHandler.applyEdit(res, "Rename to " + renameTo, toClose);
+                    LSPRenameProcessor.clearEditors();
+                    if (!isApplied) {
+                        for (VirtualFile file : toClose) {
+                            invokeLater(() -> writeAction(
+                                    () -> FileEditorManager.getInstance(project).closeFile(file)));
+                        }
+                    }
+                });
+            }
+        });
+    }
+}

--- a/src/main/java/org/wso2/lsp4intellij/features/RenameFeature.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/RenameFeature.java
@@ -47,9 +47,11 @@ import static org.wso2.lsp4intellij.utils.ApplicationUtils.writeAction;
  * keeps {@code rename(String)} as a public delegating facade with an unchanged signature, since
  * {@code LSPRenameHandler} calls it directly.
  *
- * <p>Depends directly on this editor's {@link NavigationFeature} for the reference lookup — the
- * same peer-feature composition {@link CodeActionFeature} uses for {@link DiagnosticsFeature},
- * not a stand-in for the not-yet-built {@code EditorContext}.
+ * <p>Takes reference lookup as a {@link ReferenceLookup} rather than composing
+ * {@link NavigationFeature} directly. {@code EditorEventManager.references(int, boolean, boolean)}
+ * is public and was called unqualified — so virtually — from the {@code rename} this was extracted
+ * from, and calling {@link NavigationFeature} here would skip an override of it supplied by an
+ * extension's {@code EditorEventManager} subclass.
  */
 public final class RenameFeature {
 
@@ -57,15 +59,15 @@ public final class RenameFeature {
     private final Project project;
     private final LanguageServerWrapper wrapper;
     private final TextDocumentIdentifier identifier;
-    private final NavigationFeature navigationFeature;
+    private final ReferenceLookup referenceLookup;
 
     public RenameFeature(Editor editor, Project project, LanguageServerWrapper wrapper,
-            TextDocumentIdentifier identifier, NavigationFeature navigationFeature) {
+            TextDocumentIdentifier identifier, ReferenceLookup referenceLookup) {
         this.editor = editor;
         this.project = project;
         this.wrapper = wrapper;
         this.identifier = identifier;
-        this.navigationFeature = navigationFeature;
+        this.referenceLookup = referenceLookup;
     }
 
     public void rename(String renameTo) {
@@ -83,7 +85,7 @@ public final class RenameFeature {
                 return;
             }
             VirtualFile[] openedFiles = FileEditorManager.getInstance(project).getOpenFiles();
-            Pair<List<PsiElement>, List<VirtualFile>> references = navigationFeature.references(offset, true, false);
+            Pair<List<PsiElement>, List<VirtualFile>> references = referenceLookup.references(offset, true, false);
             List<VirtualFile> toClose = new ArrayList<>();
             if (references.getSecond() != null) {
                 for (VirtualFile file : references.getSecond()) {

--- a/src/main/java/org/wso2/lsp4intellij/features/SignatureHelpFeature.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/SignatureHelpFeature.java
@@ -1,0 +1,180 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.features;
+
+import com.intellij.codeInsight.hint.HintManager;
+import com.intellij.openapi.diagnostic.Logger;
+import com.intellij.openapi.editor.Editor;
+import com.intellij.openapi.editor.LogicalPosition;
+import com.intellij.ui.Hint;
+import com.intellij.util.ui.UIUtil;
+import com.vladsch.flexmark.html.HtmlRenderer;
+import com.vladsch.flexmark.parser.Parser;
+import com.vladsch.flexmark.util.data.MutableDataSet;
+import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.ParameterInformation;
+import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureHelpParams;
+import org.eclipse.lsp4j.SignatureInformation;
+import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.jsonrpc.messages.Tuple;
+import org.wso2.lsp4intellij.client.languageserver.wrapper.LanguageServerWrapper;
+import org.wso2.lsp4intellij.utils.DocumentUtils;
+
+import java.awt.Font;
+import java.awt.Point;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+import static org.wso2.lsp4intellij.requests.Timeouts.SIGNATURE;
+import static org.wso2.lsp4intellij.utils.ApplicationUtils.invokeLater;
+import static org.wso2.lsp4intellij.utils.GUIUtils.createAndShowEditorHint;
+
+/**
+ * Calls signature help at the current caret position and shows the active signature as a hint,
+ * and decides whether a just-typed character should trigger that request.
+ *
+ * <p>Extracted from {@code EditorEventManager} as part of the feature-layer decomposition
+ * (ARCHITECTURE.md section 2.4); {@code EditorEventManager} composes one instance per editor and
+ * keeps {@code characterTyped}/{@code signatureHelp} as public delegating facades, since
+ * {@code LSPTypedHandler} calls {@code characterTyped} directly and {@code CompletionFeature}
+ * calls {@code signatureHelp} after expanding a snippet.
+ *
+ * <p>The currently shown hint is still tracked by {@code EditorEventManager} (see
+ * {@link HoverFeature}'s equivalent note), so it's injected here as a setter callback too.
+ */
+public final class SignatureHelpFeature {
+
+    private static final Logger LOG = Logger.getInstance(SignatureHelpFeature.class);
+
+    private final Editor editor;
+    private final LanguageServerWrapper wrapper;
+    private final TextDocumentIdentifier identifier;
+    private final List<String> signatureTriggers;
+    private final Consumer<Hint> hintSetter;
+
+    public SignatureHelpFeature(Editor editor, LanguageServerWrapper wrapper, TextDocumentIdentifier identifier,
+            List<String> signatureTriggers, Consumer<Hint> hintSetter) {
+        this.editor = editor;
+        this.wrapper = wrapper;
+        this.identifier = identifier;
+        this.signatureTriggers = signatureTriggers;
+        this.hintSetter = hintSetter;
+    }
+
+    /**
+     * Calls onTypeFormatting or signatureHelp if the character typed was a trigger character.
+     *
+     * @param c The character just typed
+     */
+    public void characterTyped(char c) {
+        if (signatureTriggers.contains(Character.toString(c))) {
+            signatureHelp();
+        }
+    }
+
+    /**
+     * Calls signatureHelp at the current editor caret position.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public void signatureHelp() {
+        if (editor.isDisposed()) {
+            return;
+        }
+        LogicalPosition lPos = editor.getCaretModel().getCurrentCaret().getLogicalPosition();
+        Point point = editor.logicalPositionToXY(lPos);
+        SignatureHelpParams params = new SignatureHelpParams(identifier, DocumentUtils.logicalToLSPPos(lPos, editor));
+        wrapper.pool(() -> {
+            CompletableFuture<SignatureHelp> future = wrapper.getRequestManager().signatureHelp(params);
+            SignatureHelp signatureResp = wrapper.getRequestExecutor().waitFor(future, SIGNATURE);
+            if (signatureResp == null) {
+                return;
+            }
+            try {
+                List<SignatureInformation> signatures = signatureResp.getSignatures();
+                if (signatures == null || signatures.isEmpty()) {
+                    return;
+                }
+                int activeSignatureIndex = signatureResp.getActiveSignature();
+                int activeParameterIndex = signatureResp.getActiveParameter();
+
+                SignatureInformation activeSignature = signatures.get(activeSignatureIndex);
+                String activeParameter =
+                        activeSignature.getParameters().size() > activeParameterIndex
+                        ? extractLabel(activeSignature,
+                                activeSignature.getParameters()
+                                        .get(activeParameterIndex).getLabel())
+                        : "";
+                Either<String, MarkupContent> signatureDescription =
+                        activeSignature.getDocumentation();
+                StringBuilder builder = new StringBuilder();
+                Font font = UIUtil.getLabelFont();
+                MutableDataSet options = new MutableDataSet();
+                Parser parser = Parser.builder(options).build();
+                HtmlRenderer renderer = HtmlRenderer.builder(options).build();
+                builder.append("<html>");
+                builder.append(UIUtil.getCssFontDeclaration(font));
+                List<String> result = new ArrayList<>();
+                if (!signatures.isEmpty() && signatures.get(activeSignatureIndex).getParameters() != null) {
+                    for (ParameterInformation param : signatures.get(activeSignatureIndex).getParameters()) {
+                        Either<String, MarkupContent> doc = param.getDocumentation();
+                        if (doc.isRight()) {
+                            result.add(renderer.render(parser.parse(doc.getRight().getValue())));
+                        }
+                    }
+                }
+                if (signatureDescription == null) {
+                    builder.append("<code>").append(signatures.get(activeSignatureIndex).getLabel().
+                            replace(" " + activeParameter, String.format("<font color=\"orange\"> %s</font>",
+                                    activeParameter))).append("</code>");
+                } else if (signatureDescription.isLeft()) {
+                    String description = signatureDescription.getLeft().replace(System.lineSeparator(), "<br />");
+                    builder.append("<code>").append(signatures.get(activeSignatureIndex).getLabel()
+                            .replace(" " + activeParameter, String.format("<font color=\"orange\"> %s</font>",
+                                    activeParameter))).append("</code>");
+                    builder.append("<p>").append(description).append("</p>");
+                } else if (signatureDescription.isRight()) {
+                    String string = renderer.render(parser.parse(signatures.get(activeSignatureIndex).getLabel()));
+                    builder.append("<code>").append(string).append("</code>");
+                }
+                if (!result.isEmpty()) {
+                    builder.append("<div>").append(String.join("\n", result)).append("</div>");
+                }
+                builder.append("</html>");
+                invokeLater(() -> hintSetter.accept(createAndShowEditorHint(
+                        editor, builder.toString(), point,
+                        HintManager.UNDER, HintManager.HIDE_BY_OTHER_HINT)));
+
+            } catch (Exception e) {
+                LOG.warn("Internal error occurred when processing signature help");
+            }
+        });
+    }
+
+    private String extractLabel(SignatureInformation signatureInformation,
+            Either<String, Tuple.Two<Integer, Integer>> label) {
+        if (label.isLeft()) {
+            return label.getLeft();
+        } else if (label.isRight()) {
+            return signatureInformation.getLabel().substring(label.getRight().getFirst(), label.getRight().getSecond());
+        } else {
+            return "";
+        }
+    }
+}

--- a/src/main/java/org/wso2/lsp4intellij/features/SignatureHelpFeature.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/SignatureHelpFeature.java
@@ -111,15 +111,22 @@ public final class SignatureHelpFeature {
                 if (signatures == null || signatures.isEmpty()) {
                     return;
                 }
-                int activeSignatureIndex = signatureResp.getActiveSignature();
-                int activeParameterIndex = signatureResp.getActiveParameter();
+                // getActiveSignature()/getActiveParameter() are nullable Integers per the LSP spec
+                // ("if omitted... defaults to zero"), and a server may also send an out-of-range value;
+                // unboxing a null or indexing out of range would otherwise throw here.
+                Integer activeSignatureBoxed = signatureResp.getActiveSignature();
+                int activeSignatureIndex = activeSignatureBoxed == null
+                        || activeSignatureBoxed < 0 || activeSignatureBoxed >= signatures.size()
+                        ? 0 : activeSignatureBoxed;
+                Integer activeParameterBoxed = signatureResp.getActiveParameter();
+                int activeParameterIndex = activeParameterBoxed == null || activeParameterBoxed < 0
+                        ? 0 : activeParameterBoxed;
 
                 SignatureInformation activeSignature = signatures.get(activeSignatureIndex);
+                List<ParameterInformation> parameters = activeSignature.getParameters();
                 String activeParameter =
-                        activeSignature.getParameters().size() > activeParameterIndex
-                        ? extractLabel(activeSignature,
-                                activeSignature.getParameters()
-                                        .get(activeParameterIndex).getLabel())
+                        parameters != null && parameters.size() > activeParameterIndex
+                        ? extractLabel(activeSignature, parameters.get(activeParameterIndex).getLabel())
                         : "";
                 Either<String, MarkupContent> signatureDescription =
                         activeSignature.getDocumentation();

--- a/src/main/java/org/wso2/lsp4intellij/features/SignatureHelpFeature.java
+++ b/src/main/java/org/wso2/lsp4intellij/features/SignatureHelpFeature.java
@@ -161,7 +161,11 @@ public final class SignatureHelpFeature {
                     builder.append("<code>").append(string).append("</code>");
                 }
                 if (!result.isEmpty()) {
-                    builder.append("<div>").append(String.join("\n", result)).append("</div>");
+                    // "<br/>", not a line-separator character: this joins already-rendered HTML
+                    // fragments (one per parameter's documentation), and a raw newline between two
+                    // HTML blocks is collapsed by the renderer either way - only a real HTML break
+                    // separates them visually, same reasoning as the getLeft() branch above.
+                    builder.append("<div>").append(String.join("<br/>", result)).append("</div>");
                 }
                 builder.append("</html>");
                 invokeLater(() -> hintSetter.accept(createAndShowEditorHint(
@@ -169,7 +173,7 @@ public final class SignatureHelpFeature {
                         HintManager.UNDER, HintManager.HIDE_BY_OTHER_HINT)));
 
             } catch (Exception e) {
-                LOG.warn("Internal error occurred when processing signature help");
+                LOG.warn("Internal error occurred when processing signature help", e);
             }
         });
     }

--- a/src/test/java/org/wso2/lsp4intellij/features/CodeActionFeatureTest.java
+++ b/src/test/java/org/wso2/lsp4intellij/features/CodeActionFeatureTest.java
@@ -34,7 +34,9 @@ public class CodeActionFeatureTest extends TestCase {
 
     @Override
     protected void setUp() {
-        feature = new CodeActionFeature(null, null, null, null);
+        // The override hooks are never invoked: these tests only exercise the annotation and
+        // sync-flag bookkeeping, not requestAndShowCodeActions.
+        feature = new CodeActionFeature(null, null, null, null, null);
     }
 
     public void testAnnotationsStartEmpty() {

--- a/src/test/java/org/wso2/lsp4intellij/features/CodeActionFeatureTest.java
+++ b/src/test/java/org/wso2/lsp4intellij/features/CodeActionFeatureTest.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.features;
+
+import com.intellij.lang.annotation.Annotation;
+import junit.framework.TestCase;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests for {@link CodeActionFeature}'s annotation/sync-flag bookkeeping — the pure part that
+ * needs neither the wrapper's request manager nor a real editor. The request/annotation-attaching
+ * paths ({@code codeAction}, {@code requestAndShowCodeActions}, {@code showCodeActions}) need a
+ * running server and a real editor and have no test coverage, same as before this extraction.
+ */
+public class CodeActionFeatureTest extends TestCase {
+
+    private CodeActionFeature feature;
+
+    @Override
+    protected void setUp() {
+        feature = new CodeActionFeature(null, null, null, null);
+    }
+
+    public void testAnnotationsStartEmpty() {
+        assertTrue(feature.getAnnotations().isEmpty());
+    }
+
+    public void testSetAnnotationsThenGetRoundTrips() {
+        List<Annotation> annotations = new ArrayList<>();
+        feature.setAnnotations(annotations);
+
+        assertSame(annotations, feature.getAnnotations());
+    }
+
+    public void testCodeActionSyncNotRequiredInitially() {
+        assertFalse(feature.isCodeActionSyncRequired());
+    }
+
+    public void testGetAnnotationsClearsTheSyncFlag() {
+        // There is no public way to set codeActionSyncRequired directly; this only confirms
+        // getAnnotations() doesn't leave a stale "required" flag from its initial false state.
+        feature.getAnnotations();
+
+        assertFalse(feature.isCodeActionSyncRequired());
+    }
+
+    public void testSilentAnnotationsStartsEmptyAndIsMutable() {
+        assertTrue(feature.getSilentAnnotations().isEmpty());
+
+        // documentChanged() clears this list through the same live reference.
+        feature.getSilentAnnotations().addAll(Collections.emptyList());
+        assertTrue(feature.getSilentAnnotations().isEmpty());
+    }
+
+    public void testTriggerIntentionActionsIsANoOpUntilRequested() {
+        // isTriggerIntentionActions starts false, and there is no public setter for it outside
+        // showCodeActions (which needs a running server); this must not touch the editor/wrapper
+        // fields (all null here) when the flag is unset.
+        feature.triggerIntentionActions();
+    }
+}

--- a/src/test/java/org/wso2/lsp4intellij/features/CodeActionFeatureTest.java
+++ b/src/test/java/org/wso2/lsp4intellij/features/CodeActionFeatureTest.java
@@ -16,10 +16,13 @@
 package org.wso2.lsp4intellij.features;
 
 import com.intellij.lang.annotation.Annotation;
+import com.intellij.lang.annotation.HighlightSeverity;
+import com.intellij.openapi.util.TextRange;
+import groovy.lang.Tuple3;
 import junit.framework.TestCase;
+import org.wso2.lsp4intellij.contributors.fixes.LSPCodeActionFix;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 
 /**
@@ -55,19 +58,25 @@ public class CodeActionFeatureTest extends TestCase {
     }
 
     public void testGetAnnotationsClearsTheSyncFlag() {
-        // There is no public way to set codeActionSyncRequired directly; this only confirms
-        // getAnnotations() doesn't leave a stale "required" flag from its initial false state.
+        feature.markCodeActionSyncRequiredForTest();
+        assertTrue(feature.isCodeActionSyncRequired());
+
         feature.getAnnotations();
 
         assertFalse(feature.isCodeActionSyncRequired());
     }
 
-    public void testSilentAnnotationsStartsEmptyAndIsMutable() {
+    public void testSilentAnnotationsIsTheLiveMutableList() {
         assertTrue(feature.getSilentAnnotations().isEmpty());
 
-        // documentChanged() clears this list through the same live reference.
-        feature.getSilentAnnotations().addAll(Collections.emptyList());
-        assertTrue(feature.getSilentAnnotations().isEmpty());
+        Tuple3<HighlightSeverity, TextRange, LSPCodeActionFix> annotation =
+                new Tuple3<>(HighlightSeverity.ERROR, new TextRange(0, 1), null);
+        feature.getSilentAnnotations().add(annotation);
+
+        // The same live list, not a defensive copy: documentChanged() clears the feature's
+        // silent annotations through exactly this reference.
+        assertEquals(1, feature.getSilentAnnotations().size());
+        assertSame(annotation, feature.getSilentAnnotations().get(0));
     }
 
     public void testTriggerIntentionActionsIsANoOpUntilRequested() {

--- a/src/test/java/org/wso2/lsp4intellij/features/CompletionFeatureTest.java
+++ b/src/test/java/org/wso2/lsp4intellij/features/CompletionFeatureTest.java
@@ -25,8 +25,9 @@ import java.util.List;
  * Tests for {@link CompletionFeature#getCompletionPrefix(Editor, int)} — the one piece of this
  * feature that is pure document/string logic and needs neither a language server nor the wrapper
  * it would otherwise call into. The other methods (completion request, lookup item conversion,
- * snippet expansion) need a running server or IntelliJ's completion machinery and are exercised by
- * {@code LspServerIntegrationTest} instead.
+ * snippet expansion) need a running server or IntelliJ's completion machinery and have no test
+ * coverage — {@code LspServerIntegrationTest} does not reach them; it covers only open/didOpen,
+ * edit/didChange, and close/didClose/shutdown.
  */
 public class CompletionFeatureTest extends BasePlatformTestCase {
 

--- a/src/test/java/org/wso2/lsp4intellij/features/CompletionFeatureTest.java
+++ b/src/test/java/org/wso2/lsp4intellij/features/CompletionFeatureTest.java
@@ -54,10 +54,12 @@ public class CompletionFeatureTest extends BasePlatformTestCase {
 
     private CompletionFeature newFeature(List<String> completionTriggers) {
         // editor/wrapper/identifier are null: getCompletionPrefix takes its own editor parameter
-        // and never touches them, and the edit/command/signature-help callbacks are never invoked.
+        // and never touches them, and the edit/command/signature-help callbacks and the override
+        // hooks are never invoked.
         return new CompletionFeature(null, getProject(), null, null, completionTriggers,
                 (version, edits, name, closeAfter, setCaret) -> false,
                 commands -> { },
-                () -> { });
+                () -> { },
+                null);
     }
 }

--- a/src/test/java/org/wso2/lsp4intellij/features/CompletionFeatureTest.java
+++ b/src/test/java/org/wso2/lsp4intellij/features/CompletionFeatureTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.features;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests for {@link CompletionFeature#getCompletionPrefix(Editor, int)} — the one piece of this
+ * feature that is pure document/string logic and needs neither a language server nor the wrapper
+ * it would otherwise call into. The other methods (completion request, lookup item conversion,
+ * snippet expansion) need a running server or IntelliJ's completion machinery and are exercised by
+ * {@code LspServerIntegrationTest} instead.
+ */
+public class CompletionFeatureTest extends BasePlatformTestCase {
+
+    public void testPrefixStopsAtACustomTriggerCharacter() {
+        CompletionFeature feature = newFeature(Collections.singletonList("."));
+        myFixture.configureByText("Test.txt", "foo.ba");
+
+        assertEquals("ba", feature.getCompletionPrefix(myFixture.getEditor(), 6));
+    }
+
+    public void testPrefixFallsBackToWhitespaceWithNoTriggerCharacters() {
+        CompletionFeature feature = newFeature(Collections.emptyList());
+        myFixture.configureByText("Test.txt", "hello wor");
+
+        assertEquals("wor", feature.getCompletionPrefix(myFixture.getEditor(), 9));
+    }
+
+    public void testPrefixIsTheWholeTextWhenNoDelimiterIsFound() {
+        CompletionFeature feature = newFeature(Collections.emptyList());
+        myFixture.configureByText("Test.txt", "abc");
+
+        assertEquals("abc", feature.getCompletionPrefix(myFixture.getEditor(), 3));
+    }
+
+    private CompletionFeature newFeature(List<String> completionTriggers) {
+        // editor/wrapper/identifier are null: getCompletionPrefix takes its own editor parameter
+        // and never touches them, and the edit/command/signature-help callbacks are never invoked.
+        return new CompletionFeature(null, getProject(), null, null, completionTriggers,
+                (version, edits, name, closeAfter, setCaret) -> false,
+                commands -> { },
+                () -> { });
+    }
+}

--- a/src/test/java/org/wso2/lsp4intellij/features/DiagnosticsFeatureTest.java
+++ b/src/test/java/org/wso2/lsp4intellij/features/DiagnosticsFeatureTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.features;
+
+import com.intellij.openapi.editor.Editor;
+import com.intellij.testFramework.fixtures.BasePlatformTestCase;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Tests for {@link DiagnosticsFeature}'s storage and sync-flag contract, run against a light test
+ * editor. No language server is involved: {@code publish} only stores the given diagnostics and
+ * forces a DaemonCodeAnalyzer restart, which is safe to trigger against the fixture's project.
+ */
+public class DiagnosticsFeatureTest extends BasePlatformTestCase {
+
+    private DiagnosticsFeature feature;
+
+    @Override
+    protected void setUp() throws Exception {
+        super.setUp();
+        myFixture.configureByText("Test.txt", "hello world");
+        Editor editor = myFixture.getEditor();
+        feature = new DiagnosticsFeature(editor, getProject());
+    }
+
+    public void testInitiallySyncRequiredWithNoDiagnostics() {
+        assertTrue(feature.isSyncRequired());
+        assertTrue(feature.diagnostics().isEmpty());
+    }
+
+    public void testDiagnosticsReturnsLiveContractAndClearsSyncFlag() {
+        List<Diagnostic> published = Collections.singletonList(diagnosticAt(0, 5));
+        feature.publish(published);
+
+        assertTrue(feature.isSyncRequired());
+        List<Diagnostic> read = feature.diagnostics();
+        assertEquals(1, read.size());
+        assertFalse(feature.isSyncRequired());
+    }
+
+    public void testPublishingEmptyOverEmptyIsANoOp() {
+        feature.diagnostics(); // clears the initial sync-required flag
+        assertFalse(feature.isSyncRequired());
+
+        feature.publish(new ArrayList<>());
+
+        assertFalse(feature.isSyncRequired());
+    }
+
+    public void testPublishReplacesPreviousDiagnostics() {
+        feature.publish(Collections.singletonList(diagnosticAt(0, 5)));
+        feature.publish(Collections.singletonList(diagnosticAt(6, 11)));
+
+        List<Diagnostic> current = feature.diagnostics();
+        assertEquals(1, current.size());
+        assertEquals(6, current.get(0).getRange().getStart().getCharacter());
+    }
+
+    public void testWithDiagnosticsSeesCurrentContent() {
+        feature.publish(Collections.singletonList(diagnosticAt(0, 5)));
+
+        List<Diagnostic> seen = new ArrayList<>();
+        feature.withDiagnostics(seen::addAll);
+
+        assertEquals(1, seen.size());
+    }
+
+    private static Diagnostic diagnosticAt(int startChar, int endChar) {
+        Diagnostic diagnostic = new Diagnostic();
+        diagnostic.setRange(new Range(new Position(0, startChar), new Position(0, endChar)));
+        diagnostic.setMessage("test diagnostic");
+        return diagnostic;
+    }
+}

--- a/src/test/java/org/wso2/lsp4intellij/features/SignatureHelpFeatureTest.java
+++ b/src/test/java/org/wso2/lsp4intellij/features/SignatureHelpFeatureTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2026, WSO2 LLC. (http://www.wso2.org) All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.wso2.lsp4intellij.features;
+
+import junit.framework.TestCase;
+
+import java.util.Collections;
+
+/**
+ * Tests for {@link SignatureHelpFeature#characterTyped}'s trigger-character gate — the one piece
+ * of this feature that is pure logic. A non-trigger character must be a no-op without touching the
+ * editor or wrapper at all (both are null here); the triggering path itself
+ * ({@code signatureHelp()}, which needs a real editor, wrapper, and running server) is exercised by
+ * {@code LspServerIntegrationTest} instead.
+ */
+public class SignatureHelpFeatureTest extends TestCase {
+
+    public void testNonTriggerCharacterIsANoOp() {
+        SignatureHelpFeature feature = new SignatureHelpFeature(null, null, null,
+                Collections.singletonList("("), hint -> fail("must not show a hint for a non-trigger character"));
+
+        // Would NPE on editor.isDisposed() inside signatureHelp() if the gate let it through.
+        feature.characterTyped('x');
+    }
+}

--- a/src/test/java/org/wso2/lsp4intellij/features/SignatureHelpFeatureTest.java
+++ b/src/test/java/org/wso2/lsp4intellij/features/SignatureHelpFeatureTest.java
@@ -23,8 +23,9 @@ import java.util.Collections;
  * Tests for {@link SignatureHelpFeature#characterTyped}'s trigger-character gate — the one piece
  * of this feature that is pure logic. A non-trigger character must be a no-op without touching the
  * editor or wrapper at all (both are null here); the triggering path itself
- * ({@code signatureHelp()}, which needs a real editor, wrapper, and running server) is exercised by
- * {@code LspServerIntegrationTest} instead.
+ * ({@code signatureHelp()}, which needs a real editor, wrapper, and running server) has no test
+ * coverage — {@code LspServerIntegrationTest} does not reach it; it covers only open/didOpen,
+ * edit/didChange, and close/didClose/shutdown.
  */
 public class SignatureHelpFeatureTest extends TestCase {
 


### PR DESCRIPTION
## Purpose

Phase 3 of the architecture migration: decomposes the `EditorEventManager` god class into one class per LSP feature under `org.wso2.lsp4intellij.features`, without changing any public API signature.

## Problems addressed

- `EditorEventManager` was 1672 lines implementing hover, completion, diagnostics, code actions, signature help, navigation, rename, formatting, snippet expansion, text-edit application, command execution, document-sync wiring, and Swing cursor/hint manipulation, all in one class. Every feature change touched this one file.
- Extending behavior meant subclassing `EditorEventManager` itself, inheriting every other feature along with the one being customized.
- Zero tests existed for any of this logic. The fields a test would need (diagnostics, annotations, completion triggers, the ctrl-range highlight) were private and entangled with each other and with `Editor`/`Project` state, with no seam to construct or verify one feature in isolation.

## Changes

- Extracted eight classes, in this order (one commit each): `DiagnosticsFeature`, `CompletionFeature`, `HoverFeature` + `SignatureHelpFeature`, `NavigationFeature`, `CodeActionFeature`, `RenameFeature`, `FormattingFeature`. Each is composed once per editor by `EditorEventManager`'s constructor and takes only the editor/project/wrapper/identifier state it needs — no static lookups, no reference back to `EditorEventManager`.
- `EditorEventManager` keeps every public method it exposed before this phase (`getDiagnostics`, `completion`, `createLookupItem`, `getCompletionPrefix`, `quickDoc`, `characterTyped`, `references`, `gotoLocation`, `codeAction`, `executeCommands`, `requestAndShowCodeActions`, `getSilentAnnotations`, `triggerIntentionActions`, `rename`, `reformat`, `reformatSelection`, and more) as an unchanged-signature delegating facade. This was required, not optional: `LSPAnnotator`, `LSPCompletionContributor`, `LSPTypedHandler`, `LSPQuickDocAction`, `LSPReferencesAction`, `LSPRenameHandler`/`LSPRenameProcessor`/`LSPInplaceRenamer`, `LSPCommandFix`/`LSPCodeActionFix`, `ReformatHandler`, `LSPShowReformatDialogAction`, and `LSPCaretListenerImpl` all call these directly on an `EditorEventManager` instance by concrete type, with no interface boundary to insulate a signature change.
- Where an extracted feature needs a capability that isn't extracted yet (text-edit application, LSP command execution, triggering signature help, showing the current hint), it takes it as a small constructor-injected callback (`EditApplier`, a shared `@FunctionalInterface` used by both `CompletionFeature` and `FormattingFeature`; a `Consumer<List<Command>>`; a `Runnable`; a `Consumer<Hint>`) rather than duplicating the logic or reaching into `EditorEventManager`'s private state. This stands in for the `EditorContext` shared session object `ARCHITECTURE.md` section 2.4 describes, which doesn't exist yet.
- Where one feature genuinely depends on another already-extracted feature, it composes it directly as a constructor parameter: `CodeActionFeature` takes a `DiagnosticsFeature` (diagnostic context for a code-action request, forcing re-annotation after attaching a fix); `RenameFeature` needs the same for reference lookup (files to close after a rename), but takes it through the `ReferenceLookup` interface instead, for the dispatch reason below.
- Mouse/ctrl-range navigation glue (`mouseMoved`, `mouseClicked`, `createCtrlRange`, `trySourceNavigationAndHover`, `getPos`) stays in `EditorEventManager` — it decides *whether and when* to trigger hover vs. a navigation preview vs. nothing, reading and writing the ctrl-range global slot on `EditorEventManagerBase`, which is mouse-event routing glue spanning features, not one LSP feature's logic. `EditorEventManagerBase.getIsCtrlDown()` widened from package-private to public so `HoverFeature`, now in a different package, can read it.
- Every extraction preserves behavior verbatim, including a couple of pre-existing quirks (unused locals in `createLookupItem`/`addCompletionInsertHandlers`; `DiagnosticsFeature`'s inconsistent locking between its accessor methods and its mutation path) — relocated as found, not opportunistically fixed. Four deliberate exceptions, each called out in the ADR rather than folded silently into a move: `NavigationFeature.references()` returns empty lists instead of `Pair<>(null, null)` (`LSPInplaceRenamer` NPE'd on the null); `SignatureHelpFeature` guards the nullable/out-of-range `activeSignature`/`activeParameter` indices and null-checks `getParameters()` (ADR 7c); and the six `getDiagnostics`/`getAnnotations`/`set*`/`is*SyncRequired` accessors are no longer `synchronized` on the manager instance, since the state they guard now lives on two feature objects with disjoint fields (ADR 7b).
- Self-calls that used to dispatch virtually now go back through the facade. Inside the old single class, `createLookupItem`, `addCompletionInsertHandlers`, `prepareAndRunSnippet`, `codeAction`, `resolvedCodeAction`, and `references` were called unqualified, so an `EditorEventManager` subclass supplied via `LSPExtensionManager.getExtendedEditorEventManagerFor` could override them and affect the internal path. The feature classes are `final`, so a plain self-call inside one would silently run the base implementation while the facade method stayed overridable — invisible to a signature-level API check. Three new interfaces (`CompletionOverrides`, `CodeActionOverrides`, `ReferenceLookup`), implemented by `EditorEventManager` with the signatures it already exposed, restore that dispatch (ADR 4b).
- `EditorEventManager.SNIPPET_PLACEHOLDER_REGEX` moved to `CompletionFeature`, and is kept on `EditorEventManager` as a `@Deprecated` constant so a downstream plugin recompiling against this jar still resolves it.
- Added `docs/adr/0003-feature-layer-decomposition.md`, recording these decisions in the same format as ADR 0001/0002.

## Known limitations (deliberately out of scope for this PR)

- **Folding, symbols, and commands were not moved into `org.wso2.lsp4intellij.features`.** `ARCHITECTURE.md` section 2.4's target class list names `FoldingFeature`/`SymbolFeature`/`CommandFeature`, but section 3's actual Phase 3 migration-order bullet doesn't include them, and checking the current code: `LSPFoldingRangeProvider` and `LSPSymbolContributor`/`WorkspaceSymbolProvider` already live in their own independent contributor classes (never part of `EditorEventManager`), and commands (`executeCommands`) already moved into `CodeActionFeature`. Relocating any of the three now would rename already-independent code for consistency alone.
- **No `EditorContext` yet.** The narrow injected callbacks described above are scaffolding for a later phase; they should be replaced by a reference to a real shared session object once one exists, not kept alongside it.
- **`applyEdit`/`getEditsRunnable`/`LSPTextEdit`** (the future `WorkspaceEditApplier`) and **document-lifecycle delegation to `DocumentEventManager`** (the future `DocumentSynchronizer`, section 2.3) remain in `EditorEventManager` — never in this phase's scope.

## Testing

- Full suite: 178 tests passing, 0 failures, 0 skipped (172 before this phase's first commit, +6 new). `checkstyleMain` clean; note `checkstyleTest` is disabled in `build.gradle`, so test sources are not style-checked.
- A unit test was added per feature only where a genuinely pure, isolable piece of logic existed that needed neither a running language server nor real editor UI behavior: `DiagnosticsFeatureTest`, `CompletionFeatureTest` (scoped to `getCompletionPrefix`), `SignatureHelpFeatureTest` (scoped to the trigger-character gate), `CodeActionFeatureTest` (scoped to the annotation/sync-flag bookkeeping). The two `CodeActionFeatureTest` cases covering that bookkeeping were verified by mutation — deleting the flag clear from `getAnnotations()`, and making `getSilentAnnotations()` return a defensive copy, each fail the corresponding test. Driving the sync flag required one package-private seam, `markCodeActionSyncRequiredForTest()`, because every production path that raises it sits inside `showCodeActions`, which needs a real editor and a server response.
- `HoverFeature`, `NavigationFeature`, `RenameFeature`, and `FormattingFeature` have no new test: every method needs the wrapper's request manager (a running server) or real editor navigation/selection behavior, and `LspServerIntegrationTest` doesn't reach any of these request paths (it covers only open/didOpen, edit/didChange, and close/didClose/shutdown) — a pre-existing coverage gap this phase did not introduce and was not scoped to close.
- `EditorEventManager` shrank from 1672 to 884 lines over the course of this phase.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Refactored `EditorEventManager` into eight focused feature classes.
- Preserved the public facade, extension dispatch, and existing behavior.
- Added constructor injection for feature dependencies and callbacks.
- Documented the architecture and synchronization model in ADR 0003.
- Added focused tests for diagnostics, completion, code actions, and signature help.
- Reduced `EditorEventManager` from 1,672 to 884 lines.
- All 178 tests pass, with clean `checkstyleMain`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
